### PR TITLE
docs: document GitHub Pages setup

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -1,0 +1,29 @@
+name: Deploy to GitHub Pages
+
+on:
+  push:
+    branches: [ "main" ]
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: "pages"
+  cancel-in-progress: true
+
+jobs:
+  deploy:
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/configure-pages@v5
+      - uses: actions/upload-pages-artifact@v3
+        with:
+          path: .
+      - id: deployment
+        uses: actions/deploy-pages@v4

--- a/README.md
+++ b/README.md
@@ -13,9 +13,8 @@ This project is a web-based tool for calculating salary rates in an emergency de
 To deploy the calculator online using GitHub Pages:
 
 1. Push the repository to GitHub.
-2. Enable GitHub Pages in the repository settings, using the default branch as the source.
-3. Access the live page at:
-   
-   `https://<your-github-username>.github.io/Salary-calculator/`
+2. On GitHub, open **Settings → Pages**. Under **Build and deployment**, choose *Deploy from a branch*, then select the `main` branch and the `/` (root) folder.
+3. (Optional) The workflow in `.github/workflows/pages.yml` will publish the site automatically on each push to `main`.
+4. Access the live page at `https://<your-github-username>.github.io/Salary-calculator/`.
 
 Replace `<your-github-username>` with your GitHub username.


### PR DESCRIPTION
## Summary
- clarify GitHub Pages configuration in README
- add workflow to deploy site to GitHub Pages on push to `main`

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b0cc6ff914832088a43f4125355555