### PR TITLE
Add CSV download feature

### DIFF
--- a/index.html
+++ b/index.html
@@ -119,6 +119,7 @@
         <div class="actions">
           <button class="primary" id="reset">Išvalyti</button>
           <button id="copy">Kopijuoti rezultatą (JSON)</button>
+          <button id="downloadCsv">Download CSV</button>
         </div>
       </div>
 


### PR DESCRIPTION
## Summary
- add Download CSV button to export computed results
- implement downloadCsv() to transform compute() output into CSV and trigger file download
- connect button to CSV download handler

## Testing
- `node --check app.js`


------
https://chatgpt.com/codex/tasks/task_e_68b0cd52a1f08320acbd9ecc2e88514f