### PR TITLE
Fix ESI chart by loading Chart.js UMD build

### DIFF
--- a/index.html
+++ b/index.html
@@ -222,7 +222,8 @@
     </div>
   </div>
 
-  <script src="https://cdn.jsdelivr.net/npm/chart.js" defer></script>
+  <!-- Using the UMD build of Chart.js to expose the global `Chart` constructor -->
+  <script src="https://cdn.jsdelivr.net/npm/chart.js@4.4.0/dist/chart.umd.min.js" defer></script>
   <script src="app.js" defer></script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- Load Chart.js UMD bundle so the global `Chart` object is available

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b0cf7f5f88832099a40b4c6c756b06