### PR TITLE
Fix overflowing ESI chart height

### DIFF
--- a/index.html
+++ b/index.html
@@ -117,7 +117,9 @@
         </div>
 
         <h3 style="margin-top:16px;">ESI distribution</h3>
-        <canvas id="esiChart"></canvas>
+        <div class="chart-container">
+          <canvas id="esiChart"></canvas>
+        </div>
 
         <div class="actions">
           <button class="primary" id="reset">Išvalyti</button>

--- a/styles.css
+++ b/styles.css
@@ -82,7 +82,13 @@
     .drag-handle { width: 16px; height: 16px; display:inline-block; margin-right:8px; background: linear-gradient(90deg, var(--drag) 33%, transparent 33%) 0 0/6px 2px repeat-y; border-radius:3px; }
     .drag-over { outline: 2px dashed var(--accent-2); outline-offset: -2px; }
 
-    #esiChart {
+    .chart-container {
+      position: relative;
       width: 100%;
       height: 200px;
+    }
+
+    #esiChart {
+      width: 100%;
+      height: 100%;
     }


### PR DESCRIPTION
## Summary
- wrap ESI chart in a fixed-height container so the chart no longer stretches the page
- add CSS for chart container and canvas sizing

## Testing
- `npm test` *(fails: enoent package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b0d454bdb0832088deeaef196e76ef