### PR TITLE
feat: add light/dark theme switch

### DIFF
--- a/app.js
+++ b/app.js
@@ -1,3 +1,26 @@
+    const THEME_KEY = 'ED_THEME';
+
+    const savedTheme = localStorage.getItem(THEME_KEY);
+    if (savedTheme === 'light') {
+      document.documentElement.classList.add('light-theme');
+    }
+
+    document.addEventListener('DOMContentLoaded', () => {
+      const toggle = document.getElementById('themeToggle');
+      if (toggle) {
+        toggle.checked = document.documentElement.classList.contains('light-theme');
+        toggle.addEventListener('change', (e) => {
+          if (e.target.checked) {
+            document.documentElement.classList.add('light-theme');
+            localStorage.setItem(THEME_KEY, 'light');
+          } else {
+            document.documentElement.classList.remove('light-theme');
+            localStorage.setItem(THEME_KEY, 'dark');
+          }
+        });
+      }
+    });
+
     // --- Zonų duomenys ---
     const DEFAULT_ZONES = [
       { id: 'RED',   name: 'Raudona (kritinė)',       group: 'Suaugusiųjų', cap: { D: 16, N: 12 } },

--- a/index.html
+++ b/index.html
@@ -7,6 +7,12 @@
   <link rel="stylesheet" href="styles.css">
   </head>
 <body>
+  <header class="container header">
+    <label class="switch">
+      <input id="themeToggle" type="checkbox" />
+      <span>Šviesi tema</span>
+    </label>
+  </header>
   <div class="container">
     <div class="title">
       <h1>Zoninio Koeficiento Skaičiuoklė</h1>

--- a/styles.css
+++ b/styles.css
@@ -10,6 +10,19 @@
       --border: #1f2937;    /* gray-800 */
       --drag: #334155;      /* slate-600 */
     }
+
+    .light-theme {
+      --bg: #f8fafc;        /* slate-50 */
+      --panel: #f1f5f9;     /* slate-100 */
+      --muted: #475569;     /* slate-600 */
+      --text: #0f172a;      /* slate-900 */
+      --accent: #16a34a;    /* green-600 */
+      --accent-2: #2563eb;  /* blue-600 */
+      --danger: #dc2626;    /* red-600 */
+      --card: #ffffff;      /* white */
+      --border: #e2e8f0;    /* slate-200 */
+      --drag: #cbd5e1;      /* slate-300 */
+    }
     * { box-sizing: border-box; }
     html, body { height: 100%; }
     body {
@@ -17,7 +30,13 @@
       background: linear-gradient(135deg, var(--bg), #0b1020 60%, #0a0f1a);
       color: var(--text);
     }
+
+    .light-theme body {
+      background: linear-gradient(135deg, var(--bg), #f1f5f9 60%, #e2e8f0);
+      color: var(--text);
+    }
     .container { max-width: 1140px; margin: 24px auto; padding: 16px; }
+    .header { display: flex; justify-content: flex-end; }
     .title { display: flex; align-items: center; gap: 12px; flex-wrap: wrap; }
     .badge { padding: 4px 10px; border-radius: 999px; background: #1e293b; color: var(--muted); font-size: 12px; }
     .grid { display: grid; gap: 14px; }


### PR DESCRIPTION
## Summary
- add header switch to toggle between light and dark themes
- define light theme variables and styling
- persist theme choice in localStorage and apply on load

## Testing
- `npm test` *(fails: missing package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b0e25bd62c8320bf596995ad58a504