### PR TITLE
Add KPI charts for ratio and ESI distribution

### DIFF
--- a/app.js
+++ b/app.js
@@ -59,6 +59,8 @@ if (toggle) {
       esi5: document.getElementById('esi5'),
       ratio: document.getElementById('ratio'),
       sShare: document.getElementById('sShare'),
+      ratioCanvas: document.getElementById('ratioChart'),
+      sCanvas: document.getElementById('sChart'),
       vBonus: document.getElementById('vBonus'),
       aBonus: document.getElementById('aBonus'),
       kMaxCell: document.getElementById('kMaxCell'),
@@ -91,6 +93,43 @@ if (toggle) {
       saveRateTemplate: document.getElementById('saveRateTemplate'),
       loadRateTemplate: document.getElementById('loadRateTemplate')
     };
+
+    const style = getComputedStyle(document.documentElement);
+    const accent = style.getPropertyValue('--accent').trim();
+    const borderColor = style.getPropertyValue('--border').trim();
+    const danger = style.getPropertyValue('--danger').trim();
+    const accent2 = style.getPropertyValue('--accent-2').trim();
+    const muted = style.getPropertyValue('--muted').trim();
+
+    const charts = {};
+    if (els.ratioCanvas) {
+      charts.ratio = new Chart(els.ratioCanvas, {
+        type: 'doughnut',
+        data: {
+          labels: ['N', 'Likutis'],
+          datasets: [{ data: [0, 1], backgroundColor: [accent, borderColor], borderWidth: 0 }]
+        },
+        options: {
+          rotation: -90,
+          circumference: 180,
+          cutout: '70%',
+          plugins: { legend: { display: false }, tooltip: { enabled: false } }
+        }
+      });
+    }
+    if (els.sCanvas) {
+      charts.s = new Chart(els.sCanvas, {
+        type: 'bar',
+        data: {
+          labels: ['ESI1', 'ESI2', 'ESI3', 'ESI4', 'ESI5'],
+          datasets: [{ data: [0, 0, 0, 0, 0], backgroundColor: [danger, accent2, muted, muted, muted] }]
+        },
+        options: {
+          plugins: { legend: { display: false } },
+          scales: { x: { display: false }, y: { display: false } }
+        }
+      });
+    }
 
 
     // --- Pagalbinės ---
@@ -264,6 +303,15 @@ if (toggle) {
       els.aBonus.textContent = `+${A.toFixed(2)}`;
       els.kMaxCell.textContent = kMax.toFixed(2);
       els.kZona.textContent = K.toFixed(2);
+
+      if (charts.ratio) {
+        charts.ratio.data.datasets[0].data = [Math.min(N, C), Math.max(C - Math.min(N, C), 0)];
+        charts.ratio.update();
+      }
+      if (charts.s) {
+        charts.s.data.datasets[0].data = [n1, n2, n3, n4, n5];
+        charts.s.update();
+      }
 
       els.baseDocCell.textContent = money(baseDoc);
       els.kDocCell.textContent = K.toFixed(2);

--- a/index.html
+++ b/index.html
@@ -147,11 +147,13 @@
           <div class="item">
             <div class="label">Santykis N/C</div>
             <div class="val" id="ratio">0.00</div>
+            <canvas id="ratioChart"></canvas>
             <div class="help">Apkrovos intervalas lemia V<sub>priedas</sub></div>
           </div>
           <div class="item">
             <div class="label">Aukštos skubos dalis S = (ESI1+ESI2)/N</div>
             <div class="val" id="sShare">0.00</div>
+            <canvas id="sChart"></canvas>
             <div class="help">Lemia A<sub>priedas</sub></div>
           </div>
         </div>
@@ -237,6 +239,7 @@
     </div>
   </div>
 
+  <script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
   <script src="app.js" defer></script>
 </body>
 </html>

--- a/styles.css
+++ b/styles.css
@@ -68,6 +68,7 @@
     .kpi .item { padding: 12px; border-radius: 14px; border: 1px solid var(--border); background: var(--panel); }
     .kpi .label { font-size: 12px; color: var(--muted); }
     .kpi .val { font-size: 20px; font-weight: 700; margin-top: 2px; }
+    .kpi canvas { width: 100%; max-width: 120px; height: 60px; margin-top: 8px; }
     .pill { display:inline-block; padding: 4px 8px; border-radius: 999px; font-size: 12px; border:1px solid var(--border); background:var(--panel); }
     .accent { color: var(--accent); }
     .muted { color: var(--muted); }


### PR DESCRIPTION
## Summary
- integrate Chart.js via CDN and add canvas elements for ratio and high-acuity metrics
- initialize charts in app.js and update compute() to feed real-time data
- style embedded charts to match existing KPI design

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b1386670b88320b39bd748d3056e84