### PR TITLE
Fix chart canvas height

### DIFF
--- a/app.js
+++ b/app.js
@@ -113,7 +113,8 @@ if (toggle) {
           rotation: -90,
           circumference: 180,
           cutout: '70%',
-          plugins: { legend: { display: false }, tooltip: { enabled: false } }
+          plugins: { legend: { display: false }, tooltip: { enabled: false } },
+          maintainAspectRatio: false
         }
       });
     }
@@ -126,7 +127,8 @@ if (toggle) {
         },
         options: {
           plugins: { legend: { display: false } },
-          scales: { x: { display: false }, y: { display: false } }
+          scales: { x: { display: false }, y: { display: false } },
+          maintainAspectRatio: false
         }
       });
     }

--- a/styles.css
+++ b/styles.css
@@ -68,7 +68,7 @@
     .kpi .item { padding: 12px; border-radius: 14px; border: 1px solid var(--border); background: var(--panel); }
     .kpi .label { font-size: 12px; color: var(--muted); }
     .kpi .val { font-size: 20px; font-weight: 700; margin-top: 2px; }
-    .kpi canvas { width: 100%; max-width: 120px; height: 60px; margin-top: 8px; }
+    .kpi canvas { width: 100%; max-width: 120px; height: 60px !important; margin-top: 8px; }
     .pill { display:inline-block; padding: 4px 8px; border-radius: 999px; font-size: 12px; border:1px solid var(--border); background:var(--panel); }
     .accent { color: var(--accent); }
     .muted { color: var(--muted); }


### PR DESCRIPTION
## Summary
- override KPI chart canvas height with CSS to prevent tall canvas
- disable Chart.js aspect ratio to respect desired height

## Testing
- `npm test` *(fails: ENOENT could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b145443b988320a5a50c43d455deeb