### PR TITLE
Reduce spacing around theme toggle

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -36,7 +36,8 @@
       color: var(--text);
     }
     .container { max-width: 1140px; margin: 24px auto; padding: 16px; }
-    .header { display: flex; justify-content: flex-end; }
+    .header { display: flex; justify-content: flex-end; margin: 8px auto; padding: 8px 16px; }
+    .header + .container { margin-top: 0; }
     .title { display: flex; align-items: center; gap: 12px; flex-wrap: wrap; }
     .badge { padding: 4px 10px; border-radius: 999px; background: var(--panel); color: var(--muted); font-size: 12px; }
     .grid { display: grid; gap: 14px; }


### PR DESCRIPTION
## Summary
- tighten header spacing around theme toggle
- remove extra gap before main content

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b1479e8b808320a1aa1f4f2935d0c9