### PR TITLE
Remove page subtitle

### DIFF
--- a/index.html
+++ b/index.html
@@ -16,7 +16,6 @@
   <div class="container">
     <div class="title">
       <h1>Zoninio Koeficiento Skaičiuoklė</h1>
-      <span class="badge">V2 · triažas + apkrova · be kokybės rodiklių</span>
     </div>
 
     <div class="grid grid-2">
@@ -167,14 +166,14 @@
               <td>V<sub>priedas</sub> (apkrova)</td>
               <td id="vBonus">+0.00</td>
               <td>
-                ≤0.8 → 0.00 · (0.8–1.0] → 0.05 · (1.0–1.25] → 0.10 · >1.25 → 0.15
+                ≤0.8 → 0.00 · (0.8–1.0] → 0.05 · (1.0–1.25] → 0.10 · &gt;1.25 → 0.15
               </td>
             </tr>
             <tr>
               <td>A<sub>priedas</sub> (triažas)</td>
               <td id="aBonus">+0.00</td>
               <td>
-                ≤10% → 0.00 · (10–20]% → 0.05 · (20–30]% → 0.10 · >30% → 0.15
+                ≤10% → 0.00 · (10–20]% → 0.05 · (20–30]% → 0.10 · &gt;30% → 0.15
               </td>
             </tr>
             <tr>

--- a/styles.css
+++ b/styles.css
@@ -39,7 +39,6 @@
     .header { display: flex; justify-content: flex-end; margin: 8px auto; padding: 8px 16px; }
     .header + .container { margin-top: 0; }
     .title { display: flex; align-items: center; gap: 12px; flex-wrap: wrap; }
-    .badge { padding: 4px 10px; border-radius: 999px; background: var(--panel); color: var(--muted); font-size: 12px; }
     .grid { display: grid; gap: 14px; }
     @media (min-width: 960px) { .grid-2 { grid-template-columns: 1.2fr 0.8fr; } }
     .card {


### PR DESCRIPTION
## Summary
- remove descriptive badge after main page title
- drop unused `.badge` CSS rule and escape unescaped '>' characters

## Testing
- `node --check app.js`
- `npx --yes htmlhint index.html >/tmp/htmlhint.log && cat /tmp/htmlhint.log`


------
https://chatgpt.com/codex/tasks/task_e_68b15c223d788320bcf2fe763e67a8ef