### PR TITLE
refactor: move inline styles into CSS classes

### DIFF
--- a/index.html
+++ b/index.html
@@ -37,7 +37,7 @@
         <div class="row">
           <div>
             <label for="zone">Zona</label>
-            <div class="row" style="grid-template-columns: 1fr auto; gap:8px;">
+            <div class="row zone-row">
               <select id="zone"></select>
               <button id="manageZones" type="button">Tvarkyti zonas</button>
             </div>
@@ -96,7 +96,7 @@
           </div>
         </div>
 
-        <div style="margin:10px 0 6px;">
+        <div class="switch-block">
           <label class="switch">
             <input id="linkN" type="checkbox" checked />
             <span>Naudoti N = ESI1+ESI2+ESI3+ESI4+ESI5</span>
@@ -189,7 +189,7 @@
           </tbody>
         </table>
 
-        <h2 style="margin-top:14px;">Tarifai pagal rolę</h2>
+        <h2 class="role-heading">Tarifai pagal rolę</h2>
         <table class="table">
           <thead>
             <tr><th>Rolė</th><th>Bazė (€/val.)</th><th>Koef. K<sub>zona</sub></th><th>Galutinis (€/val.)</th><th>Pam. alga (€/pam.)</th><th>Mėn. alga (€/mėn.)</th></tr>
@@ -213,23 +213,23 @@
     <div class="dialog">
       <h3>Zonų tvarkymas</h3>
       <div class="help">Pridėkite, redaguokite, <strong>rikiuokite (drag&drop)</strong> ir grupuokite zonas. Pakeitimai saugomi šiame įrenginyje (<em>localStorage</em>).</div>
-      <div class="toolbar" style="margin:10px 0;">
+      <div class="toolbar">
         <button id="addZone" class="icon-btn">+ Pridėti zoną</button>
         <div class="spacer"></div>
         <button id="defaultsZones" class="warn">Numatytosios zonos</button>
         <button id="closeZoneModal">Uždaryti</button>
         <button id="saveZonesBtn" class="primary">Išsaugoti</button>
       </div>
-      <table class="table" style="margin-top:6px;">
+      <table class="table modal-table">
         <thead>
           <tr>
-            <th style="width:4%"></th>
-            <th style="width:28%">Pavadinimas</th>
-            <th style="width:14%">Kodas</th>
-            <th style="width:14%">Grupė</th>
-            <th style="width:14%">Talpa D</th>
-            <th style="width:14%">Talpa N</th>
-            <th style="width:12%">Šalinti</th>
+            <th class="w-4"></th>
+            <th class="w-28">Pavadinimas</th>
+            <th class="w-14">Kodas</th>
+            <th class="w-14">Grupė</th>
+            <th class="w-14">Talpa D</th>
+            <th class="w-14">Talpa N</th>
+            <th class="w-12">Šalinti</th>
           </tr>
         </thead>
         <tbody id="zoneTbody"></tbody>

--- a/styles.css
+++ b/styles.css
@@ -57,14 +57,17 @@
     input[type="number"]:focus, input[type="date"]:focus, input[type="text"]:focus, select:focus { border-color: var(--accent-2); }
     .row { display: grid; grid-template-columns: 1fr 1fr; gap: 12px; }
     .row-3 { display: grid; grid-template-columns: 1fr 1fr 1fr; gap: 12px; }
+    .zone-row { grid-template-columns: 1fr auto; gap: 8px; }
     .help { font-size: 12px; color: var(--muted); margin-top: 6px; }
     .switch { display: inline-flex; align-items: center; gap: 8px; user-select: none; cursor: pointer; font-size: 13px; color: var(--muted); }
     .switch input { appearance: none; width: 38px; height: 22px; background: var(--border); border-radius: 999px; position: relative; outline: none; transition: background .2s; }
     .switch input::after { content:""; position: absolute; top: 3px; left: 3px; width: 16px; height: 16px; background: #fff; border-radius: 50%; transition: transform .2s; }
     .switch input:checked { background: #1f7af8; }
     .switch input:checked::after { transform: translateX(16px); }
+    .switch-block { margin: 10px 0 6px; }
 
     .kpi { display: grid; grid-template-columns: repeat(2, minmax(0,1fr)); gap: 12px; margin-top: 8px; }
+    .role-heading { margin-top: 14px; }
     .kpi .item { padding: 12px; border-radius: 14px; border: 1px solid var(--border); background: var(--panel); }
     .kpi .label { font-size: 12px; color: var(--muted); }
     .kpi .val { font-size: 20px; font-weight: 700; margin-top: 2px; }
@@ -92,8 +95,14 @@
     .modal.active { display: flex; }
     .dialog { width: min(980px, 96vw); background: radial-gradient(1000px 400px at 10% 0%, var(--panel), var(--card)); border: 1px solid var(--border); border-radius: 16px; padding: 16px; box-shadow: 0 20px 50px rgba(0,0,0,0.5); }
     .dialog h3 { margin: 6px 0 10px; font-size: 18px; }
-    .dialog .toolbar { display:flex; gap:8px; align-items:center; flex-wrap:wrap; margin-bottom: 8px; }
+    .toolbar { margin: 10px 0; }
+    .dialog .toolbar { display:flex; gap:8px; align-items:center; flex-wrap:wrap; }
     .dialog .toolbar .spacer { flex: 1; }
+    .modal-table { margin-top: 6px; }
+    .w-4 { width:4%; }
+    .w-28 { width:28%; }
+    .w-14 { width:14%; }
+    .w-12 { width:12%; }
     .icon-btn { width: 36px; height: 36px; border-radius: 10px; display:flex; align-items:center; justify-content:center; }
     .small { font-size: 12px; }
 


### PR DESCRIPTION
## Summary
- extract inline styles from index.html into dedicated CSS classes
- reuse new classes for zone selection row, toolbar, and modal table elements

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b1a0cd0900832096ac549a2a702cc2