### PR TITLE
fix: use solid background color

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -27,12 +27,12 @@
     html, body { height: 100%; }
     body {
       margin: 0; font-family: system-ui, -apple-system, Segoe UI, Roboto, Ubuntu, "Helvetica Neue", Arial;
-      background: linear-gradient(135deg, var(--bg), #0b1020 60%, #0a0f1a);
+      background: var(--bg);
       color: var(--text);
     }
 
     .light-theme body {
-      background: linear-gradient(135deg, var(--bg), #f1f5f9 60%, #e2e8f0);
+      background: var(--bg);
       color: var(--text);
     }
     .container { max-width: 1140px; margin: 24px auto; padding: 16px; }


### PR DESCRIPTION
## Summary
- use a solid background color for body in both themes to remove uneven gradient

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b1a78be72883208bb2c95b0f1972c3