### PR TITLE
Sanitize compute inputs and add robustness tests

### DIFF
--- a/compute.js
+++ b/compute.js
@@ -20,6 +20,10 @@ function getBonus(metric, table) {
   return 0;
 }
 
+function sanitize(value) {
+  return Number.isFinite(value) ? Math.max(0, value) : 0;
+}
+
 function compute({
   C,
   kMax,
@@ -35,37 +39,48 @@ function compute({
   n5,
   N,
 }) {
-  const totalN = typeof N === 'number' ? N : n1 + n2 + n3 + n4 + n5;
-  const ratio = C > 0 ? totalN / C : 0;
+  const c = sanitize(C);
+  const k = sanitize(kMax);
+  const sh = sanitize(shiftH);
+  const mh = sanitize(monthH);
+  const sN1 = sanitize(n1);
+  const sN2 = sanitize(n2);
+  const sN3 = sanitize(n3);
+  const sN4 = sanitize(n4);
+  const sN5 = sanitize(n5);
+  const totalN = Number.isFinite(N)
+    ? Math.max(0, N)
+    : sN1 + sN2 + sN3 + sN4 + sN5;
+  const ratio = c > 0 ? totalN / c : 0;
   const V = getBonus(ratio, THRESHOLDS.V_BONUS);
-  const high = n1 + n2;
+  const high = sN1 + sN2;
   const S = totalN > 0 ? high / totalN : 0;
   const A = getBonus(S, THRESHOLDS.A_BONUS);
-  const K = Math.min(1 + V + A, kMax);
+  const K = Math.max(0, Math.min(1 + V + A, k));
 
-  const finalDoc = baseDoc * K;
-  const finalNurse = baseNurse * K;
-  const finalAssist = baseAssist * K;
+  const finalDoc = Math.max(0, baseDoc * K);
+  const finalNurse = Math.max(0, baseNurse * K);
+  const finalAssist = Math.max(0, baseAssist * K);
 
-  const shiftDoc = finalDoc * shiftH;
-  const shiftNurse = finalNurse * shiftH;
-  const shiftAssist = finalAssist * shiftH;
+  const shiftDoc = finalDoc * sh;
+  const shiftNurse = finalNurse * sh;
+  const shiftAssist = finalAssist * sh;
 
-  const monthDoc = finalDoc * monthH;
-  const monthNurse = finalNurse * monthH;
-  const monthAssist = finalAssist * monthH;
+  const monthDoc = finalDoc * mh;
+  const monthNurse = finalNurse * mh;
+  const monthAssist = finalAssist * mh;
 
   return {
     N: totalN,
-    ESI: { n1, n2, n3, n4, n5 },
+    ESI: { n1: sN1, n2: sN2, n3: sN3, n4: sN4, n5: sN5 },
     ratio,
     S,
     V_bonus: V,
     A_bonus: A,
-    K_max: kMax,
+    K_max: k,
     K_zona: K,
-    shift_hours: shiftH,
-    month_hours: monthH,
+    shift_hours: sh,
+    month_hours: mh,
     base_rates: {
       doctor: baseDoc,
       nurse: baseNurse,

--- a/tests/compute.test.js
+++ b/tests/compute.test.js
@@ -63,4 +63,70 @@ describe('compute core logic', () => {
     expect(result.A_bonus).toBe(0.15);
     expect(result.K_zona).toBeCloseTo(1.30);
   });
+
+  test('handles NaN inputs with safe defaults', () => {
+    const result = compute({
+      C: NaN,
+      N: NaN,
+      kMax: NaN,
+      baseDoc: 10,
+      baseNurse: 10,
+      baseAssist: 10,
+      shiftH: NaN,
+      monthH: NaN,
+      n1: NaN,
+      n2: NaN,
+      n3: NaN,
+      n4: NaN,
+      n5: NaN,
+    });
+    expect(result.N).toBe(0);
+    expect(result.K_zona).toBe(0);
+    expect(result.shift_salary.doctor).toBe(0);
+    expect(result.month_salary.doctor).toBe(0);
+  });
+
+  test('clamps negative values to zero', () => {
+    const result = compute({
+      C: -100,
+      N: -50,
+      kMax: -1,
+      baseDoc: 10,
+      baseNurse: 10,
+      baseAssist: 10,
+      shiftH: -10,
+      monthH: -160,
+      n1: -5,
+      n2: -5,
+      n3: -5,
+      n4: -5,
+      n5: -5,
+    });
+    expect(result.N).toBe(0);
+    expect(result.ratio).toBe(0);
+    expect(result.shift_hours).toBe(0);
+    expect(result.month_hours).toBe(0);
+  });
+
+  test('ignores infinite values', () => {
+    const result = compute({
+      C: Infinity,
+      N: Infinity,
+      kMax: Infinity,
+      baseDoc: 10,
+      baseNurse: 10,
+      baseAssist: 10,
+      shiftH: Infinity,
+      monthH: Infinity,
+      n1: Infinity,
+      n2: Infinity,
+      n3: Infinity,
+      n4: Infinity,
+      n5: Infinity,
+    });
+    expect(result.N).toBe(0);
+    expect(result.K_zona).toBe(0);
+    expect(result.shift_salary.doctor).toBe(0);
+    expect(result.month_salary.doctor).toBe(0);
+  });
 });


### PR DESCRIPTION
## Summary
- Sanitize capacity, totals, limits, and hour values using `Number.isFinite` and clamp to non-negative values
- Clamp final salary calculations to avoid negative results
- Replace `typeof` checks with `Number.isFinite`
- Add unit tests for NaN, negative, and infinite inputs

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b2be4a4c9483209228ef7c67100206