### PR TITLE
Freeze threshold configuration

### DIFF
--- a/compute.js
+++ b/compute.js
@@ -1,17 +1,17 @@
-const THRESHOLDS = {
-  V_BONUS: [
-    { limit: 0.80, value: 0.00 },
-    { limit: 1.00, value: 0.05 },
-    { limit: 1.25, value: 0.10 },
-    { limit: Infinity, value: 0.15 },
-  ],
-  A_BONUS: [
-    { limit: 0.10, value: 0.00 },
-    { limit: 0.20, value: 0.05 },
-    { limit: 0.30, value: 0.10 },
-    { limit: Infinity, value: 0.15 },
-  ],
-};
+const THRESHOLDS = Object.freeze({
+  V_BONUS: Object.freeze([
+    Object.freeze({ limit: 0.80, value: 0.00 }),
+    Object.freeze({ limit: 1.00, value: 0.05 }),
+    Object.freeze({ limit: 1.25, value: 0.10 }),
+    Object.freeze({ limit: Infinity, value: 0.15 }),
+  ]),
+  A_BONUS: Object.freeze([
+    Object.freeze({ limit: 0.10, value: 0.00 }),
+    Object.freeze({ limit: 0.20, value: 0.05 }),
+    Object.freeze({ limit: 0.30, value: 0.10 }),
+    Object.freeze({ limit: Infinity, value: 0.15 }),
+  ]),
+});
 
 function getBonus(metric, table) {
   for (const { limit, value } of table) {
@@ -104,7 +104,7 @@ function compute({
   };
 }
 
-const exported = { THRESHOLDS, getBonus, compute };
+const exported = Object.freeze({ THRESHOLDS, getBonus, compute });
 
 if (typeof module !== 'undefined') {
   module.exports = exported;


### PR DESCRIPTION
## Summary
- prevent runtime mutation of bonus thresholds by freezing the configuration and export object

## Testing
- `npm test`
- `npx jest tests/compute.test.js tests/csv.test.js --runInBand`


------
https://chatgpt.com/codex/tasks/task_e_68b374f86ecc8320bb657731dbd8e8cf