### PR TITLE
Allow configurable bonus thresholds with persisted settings

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,10 @@ npm install
 npm test
 ```
 
+## Adjusting Bonus Thresholds
+
+The calculator allows customizing the occupancy (V) and acuity (A) bonus thresholds. Click **Redaguoti priedus** in the interface to open a modal where you can edit the `V_BONUS` and `A_BONUS` arrays in JSON form. Saved thresholds persist in your browser's `localStorage` under the key `ED_THRESHOLDS`.
+
 ## GitHub Pages
 
 To deploy the calculator online using GitHub Pages:

--- a/app.js
+++ b/app.js
@@ -30,9 +30,36 @@ if (toggle) {
 
     const LS_KEY = 'ED_ZONES_V2';
     const LS_RATE_KEY = 'ED_RATE_TEMPLATE_V2';
+    const THRESHOLDS_KEY = 'ED_THRESHOLDS';
 
     function clone(obj){ return JSON.parse(JSON.stringify(obj)); }
     function sanitizeId(txt){ const s = (txt||'').toString().toUpperCase().replace(/[^A-Z0-9]+/g,'_').replace(/^_|_$/g,''); return s || 'ZONE_' + Math.random().toString(36).slice(2,6).toUpperCase(); }
+
+    function stringifyThresholds(t){
+      return JSON.stringify(t, (k,v)=> v===Infinity ? 'Infinity' : v, 2);
+    }
+    function parseThresholds(str){
+      return JSON.parse(str, (k,v)=> v === 'Infinity' ? Infinity : v);
+    }
+    function loadThresholds(){
+      try {
+        const j = localStorage.getItem(THRESHOLDS_KEY);
+        if (j){
+          return parseThresholds(j);
+        }
+      } catch (err){
+        console.error('Failed to load thresholds', err);
+      }
+      return clone(computeCore.THRESHOLDS);
+    }
+    function saveThresholds(t){
+      try {
+        localStorage.setItem(THRESHOLDS_KEY, stringifyThresholds(t));
+      } catch (err){
+        console.error('Failed to save thresholds', err);
+        alert('Nepavyko išsaugoti priedų ribų. Patikrinkite naršyklės nustatymus.');
+      }
+    }
 
     function loadZones(){
       try {
@@ -57,6 +84,7 @@ if (toggle) {
     }
 
     let ZONES = loadZones();
+    let THRESHOLDS = loadThresholds();
 
     // --- Elementai ---
     const els = {
@@ -111,7 +139,13 @@ if (toggle) {
       defaultsZones: document.getElementById('defaultsZones'),
       closeZoneModal: document.getElementById('closeZoneModal'),
       saveRateTemplate: document.getElementById('saveRateTemplate'),
-      loadRateTemplate: document.getElementById('loadRateTemplate')
+      loadRateTemplate: document.getElementById('loadRateTemplate'),
+      manageThresholds: document.getElementById('manageThresholds'),
+      thresholdModal: document.getElementById('thresholdModal'),
+      thresholdsInput: document.getElementById('thresholdsInput'),
+      saveThresholdsBtn: document.getElementById('saveThresholdsBtn'),
+      defaultsThresholds: document.getElementById('defaultsThresholds'),
+      closeThresholdModal: document.getElementById('closeThresholdModal')
     };
 
     const style = getComputedStyle(document.documentElement);
@@ -268,6 +302,31 @@ if (toggle) {
 
     function resetToDefaults(){ if (confirm('Atstatyti numatytąsias zonas? Jūsų sąrašas bus pakeistas.')) { ZONES = clone(DEFAULT_ZONES); saveZones(ZONES); renderZoneEditor(); renderZoneSelect(false); } }
 
+    // --- Priedų ribų modalas ---
+    function openThresholdModal(){
+      els.thresholdsInput.value = stringifyThresholds(THRESHOLDS);
+      els.thresholdModal.classList.add('active');
+    }
+    function closeThresholdModal(){ els.thresholdModal.classList.remove('active'); }
+    function saveThresholdsAndClose(){
+      try {
+        THRESHOLDS = parseThresholds(els.thresholdsInput.value);
+        saveThresholds(THRESHOLDS);
+        compute();
+        closeThresholdModal();
+      } catch (err){
+        alert('Neteisingas JSON formatas.');
+      }
+    }
+    function resetThresholds(){
+      if (confirm('Atstatyti numatytąsias priedų ribas?')){
+        THRESHOLDS = clone(computeCore.THRESHOLDS);
+        els.thresholdsInput.value = stringifyThresholds(THRESHOLDS);
+        saveThresholds(THRESHOLDS);
+        compute();
+      }
+    }
+
     // --- Tarifų šablonas ---
     function saveRateTemplate(){
       const payload = {
@@ -314,7 +373,7 @@ if (toggle) {
         n4,
         n5,
         N,
-      });
+      }, THRESHOLDS);
 
       els.ratio.textContent = fmt(data.ratio);
       els.sShare.textContent = fmt(data.S);
@@ -484,6 +543,12 @@ function downloadCsv(){
     els.saveZonesBtn.addEventListener('click', saveZonesAndClose);
     els.defaultsZones.addEventListener('click', resetToDefaults);
     els.closeZoneModal.addEventListener('click', closeZoneModal);
+
+    // Priedų ribų modalas
+    els.manageThresholds.addEventListener('click', openThresholdModal);
+    els.saveThresholdsBtn.addEventListener('click', saveThresholdsAndClose);
+    els.defaultsThresholds.addEventListener('click', resetThresholds);
+    els.closeThresholdModal.addEventListener('click', closeThresholdModal);
 
     // Tarifų šablonai
     els.saveRateTemplate.addEventListener('click', (e)=>{ e.preventDefault(); saveRateTemplate(); });

--- a/compute.js
+++ b/compute.js
@@ -38,7 +38,7 @@ function compute({
   n4,
   n5,
   N,
-}) {
+}, thresholds = THRESHOLDS) {
   const c = sanitize(C);
   const k = sanitize(kMax);
   const sh = sanitize(shiftH);
@@ -52,10 +52,10 @@ function compute({
     ? Math.max(0, N)
     : sN1 + sN2 + sN3 + sN4 + sN5;
   const ratio = c > 0 ? totalN / c : 0;
-  const V = getBonus(ratio, THRESHOLDS.V_BONUS);
+  const V = getBonus(ratio, thresholds.V_BONUS || THRESHOLDS.V_BONUS);
   const high = sN1 + sN2;
   const S = totalN > 0 ? high / totalN : 0;
-  const A = getBonus(S, THRESHOLDS.A_BONUS);
+  const A = getBonus(S, thresholds.A_BONUS || THRESHOLDS.A_BONUS);
   const K = Math.max(0, Math.min(1 + V + A, k));
 
   const finalDoc = Math.max(0, baseDoc * K);

--- a/index.html
+++ b/index.html
@@ -137,6 +137,7 @@
           <button class="primary" id="reset">Išvalyti</button>
           <button id="copy">Kopijuoti rezultatą (JSON)</button>
           <button id="downloadCsv">Download CSV</button>
+          <button id="manageThresholds" type="button">Redaguoti priedus</button>
         </div>
       </div>
 
@@ -235,6 +236,21 @@
         <tbody id="zoneTbody"></tbody>
       </table>
       <div class="help small">Pastaba: <strong>Kodas</strong> turi būti unikalus (pvz., RED, YEL, GRN). Grupę galite įvesti savo (pvz., „Suaugusiųjų“, „Vaikų“).</div>
+    </div>
+  </div>
+
+  <!-- PRIEDŲ RIBŲ MODALAS -->
+  <div class="modal" id="thresholdModal" aria-hidden="true">
+    <div class="dialog">
+      <h3>Priedų ribos</h3>
+      <div class="help">Redaguokite V_BONUS ir A_BONUS JSON formatu. Naudokite "Infinity" paskutinei ribai.</div>
+      <textarea id="thresholdsInput" rows="10" style="width:100%;"></textarea>
+      <div class="toolbar">
+        <button id="defaultsThresholds" class="warn">Numatytosios</button>
+        <div class="spacer"></div>
+        <button id="closeThresholdModal">Uždaryti</button>
+        <button id="saveThresholdsBtn" class="primary">Išsaugoti</button>
+      </div>
     </div>
   </div>
 

--- a/tests/compute.test.js
+++ b/tests/compute.test.js
@@ -150,4 +150,37 @@ describe('compute core logic', () => {
     expect(result.shift_salary.doctor).toBe(0);
     expect(result.month_salary.doctor).toBe(0);
   });
+
+  test('custom thresholds adjust bonuses', () => {
+    const thresholds = {
+      V_BONUS: [
+        { limit: 0.5, value: 0 },
+        { limit: 1.0, value: 0.2 },
+        { limit: Infinity, value: 0.4 },
+      ],
+      A_BONUS: [
+        { limit: 0.2, value: 0 },
+        { limit: 0.4, value: 0.1 },
+        { limit: Infinity, value: 0.2 },
+      ],
+    };
+    const result = compute({
+      C: 100,
+      N: 150,
+      kMax: 2,
+      baseDoc: 10,
+      baseNurse: 10,
+      baseAssist: 10,
+      shiftH: 0,
+      monthH: 0,
+      n1: 30,
+      n2: 15,
+      n3: 105,
+      n4: 0,
+      n5: 0,
+    }, thresholds);
+    expect(result.V_bonus).toBe(0.4);
+    expect(result.A_bonus).toBe(0.1);
+    expect(result.K_zona).toBeCloseTo(1.5);
+  });
 });


### PR DESCRIPTION
## Summary
- Refactor core compute logic to accept optional bonus threshold configuration
- Add UI and localStorage persistence for editing V and A bonus thresholds
- Document and test custom threshold behaviour

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b40504707c8320829ea5aa8837179c