### PR TITLE
feat: support dynamic roles

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Salary Calculator
 
-This project is a web-based tool for calculating salary rates in an emergency department. It computes a zone coefficient based on patient load and triage levels, then applies it to base hourly wages for doctors, nurses and assistants to produce final pay rates.
+This project is a web-based tool for calculating salary rates in an emergency department. It computes a zone coefficient based on patient load and triage levels, then applies it to base hourly wages for any number of staff roles to produce final pay rates.
 
 You can also enter shift length and total monthly hours to see estimated earnings per shift or per month.
 
@@ -18,6 +18,10 @@ Install dependencies and run the Jest test suite:
 npm install
 npm test
 ```
+
+## Custom Roles
+
+Role definitions are editable and persisted in your browser's `localStorage`. Use the **+ Pridėti rolę** button to add positions or remove existing ones. Base rate templates save and load values for all defined roles.
 
 ## Adjusting Bonus Thresholds
 

--- a/app.js
+++ b/app.js
@@ -83,8 +83,57 @@ if (toggle) {
       }
     }
 
+    const DEFAULT_ROLES = [
+      { id: 'doctor', name: 'Gydytojas' },
+      { id: 'nurse', name: 'Slaugytojas' },
+      { id: 'assistant', name: 'Padėjėjas' },
+    ];
+    const ROLE_KEY = 'ED_ROLES';
+    function loadRoles(){
+      try {
+        const j = localStorage.getItem(ROLE_KEY);
+        if (j){
+          const arr = JSON.parse(j);
+          if (Array.isArray(arr)) return arr;
+        }
+      } catch (err){
+        console.error('Failed to load roles', err);
+      }
+      return clone(DEFAULT_ROLES);
+    }
+    function saveRoles(rs){
+      try {
+        localStorage.setItem(ROLE_KEY, JSON.stringify(rs));
+      } catch (err){
+        console.error('Failed to save roles', err);
+      }
+    }
+
     let ZONES = loadZones();
     let THRESHOLDS = loadThresholds();
+    let ROLES = loadRoles();
+
+    function renderRoleInputs(){
+      els.roleInputs.innerHTML = '';
+      ROLES.forEach(r => {
+        const div = document.createElement('div');
+        div.className = 'role-row';
+        div.dataset.id = r.id;
+        div.innerHTML = `<input type="text" class="role-name" value="${r.name}" />`+
+          `<input type="number" class="role-base" min="0" step="0.01" value="0" />`+
+          `<button type="button" class="remove-role">×</button>`;
+        els.roleInputs.appendChild(div);
+      });
+    }
+
+    function addRole(){
+      const id = 'ROLE_' + Math.random().toString(36).slice(2,6).toUpperCase();
+      ROLES.push({ id, name: 'Nauja rolė' });
+      saveRoles(ROLES);
+      renderRoleInputs();
+      loadRateTemplate();
+      compute();
+    }
 
     // --- Elementai ---
     const els = {
@@ -96,9 +145,9 @@ if (toggle) {
       kmax: document.getElementById('kmax'),
       shiftHours: document.getElementById('shiftHours'),
       monthHours: document.getElementById('monthHours'),
-      baseRateDoc: document.getElementById('baseRateDoc'),
-      baseRateNurse: document.getElementById('baseRateNurse'),
-      baseRateAssist: document.getElementById('baseRateAssist'),
+      roleInputs: document.getElementById('roleInputs'),
+      addRole: document.getElementById('addRole'),
+      roleRatesBody: document.getElementById('roleRatesBody'),
       linkN: document.getElementById('linkN'),
       esi1: document.getElementById('esi1'),
       esi2: document.getElementById('esi2'),
@@ -113,21 +162,6 @@ if (toggle) {
       aBonus: document.getElementById('aBonus'),
       kMaxCell: document.getElementById('kMaxCell'),
       kZona: document.getElementById('kZona'),
-      baseDocCell: document.getElementById('baseDocCell'),
-      kDocCell: document.getElementById('kDocCell'),
-      finalDocCell: document.getElementById('finalDocCell'),
-      shiftDocCell: document.getElementById('shiftDocCell'),
-      monthDocCell: document.getElementById('monthDocCell'),
-      baseNurseCell: document.getElementById('baseNurseCell'),
-      kNurseCell: document.getElementById('kNurseCell'),
-      finalNurseCell: document.getElementById('finalNurseCell'),
-      shiftNurseCell: document.getElementById('shiftNurseCell'),
-      monthNurseCell: document.getElementById('monthNurseCell'),
-      baseAssistCell: document.getElementById('baseAssistCell'),
-      kAssistCell: document.getElementById('kAssistCell'),
-      finalAssistCell: document.getElementById('finalAssistCell'),
-      shiftAssistCell: document.getElementById('shiftAssistCell'),
-      monthAssistCell: document.getElementById('monthAssistCell'),
       reset: document.getElementById('reset'),
       copy: document.getElementById('copy'),
       downloadCsv: document.getElementById('downloadCsv'),
@@ -329,15 +363,29 @@ if (toggle) {
 
     // --- Tarifų šablonas ---
     function saveRateTemplate(){
-      const payload = {
-        doc: toNum(els.baseRateDoc.value),
-        nurse: toNum(els.baseRateNurse.value),
-        assist: toNum(els.baseRateAssist.value)
-      };
+      const payload = {};
+      els.roleInputs.querySelectorAll('.role-row').forEach(row => {
+        const id = row.dataset.id;
+        const base = toNum(row.querySelector('.role-base').value);
+        payload[id] = base;
+      });
       try { localStorage.setItem(LS_RATE_KEY, JSON.stringify(payload)); alert('Tarifų šablonas įsimintas.'); } catch {}
     }
     function loadRateTemplate(){
-      try { const j = localStorage.getItem(LS_RATE_KEY); if (j){ const t = JSON.parse(j); if (t){ els.baseRateDoc.value = t.doc ?? 0; els.baseRateNurse.value = t.nurse ?? 0; els.baseRateAssist.value = t.assist ?? 0; compute(); return; } } } catch {}
+      try {
+        const j = localStorage.getItem(LS_RATE_KEY);
+        if (j){
+          const t = JSON.parse(j);
+          if (t){
+            els.roleInputs.querySelectorAll('.role-row').forEach(row => {
+              const id = row.dataset.id;
+              row.querySelector('.role-base').value = t[id] ?? 0;
+            });
+            compute();
+            return;
+          }
+        }
+      } catch {}
       alert('Nerasta išsaugoto šablono.');
     }
 
@@ -345,9 +393,6 @@ if (toggle) {
     function compute(){
       const C = Math.max(0, toNum(els.capacity.value));
       const kMax = Math.min(2, Math.max(1, toNum(els.kmax.value)));
-      const baseDoc = Math.max(0, toNum(els.baseRateDoc.value));
-      const baseNurse = Math.max(0, toNum(els.baseRateNurse.value));
-      const baseAssist = Math.max(0, toNum(els.baseRateAssist.value));
       const shiftH = Math.max(0, toNum(els.shiftHours.value));
       const monthH = Math.max(0, toNum(els.monthHours.value));
       let n1 = Math.max(0, toNum(els.esi1.value));
@@ -359,12 +404,16 @@ if (toggle) {
       let N = Math.max(0, toNum(els.N.value));
       if (els.linkN.checked){ N = n1 + n2 + n3 + n4 + n5; els.N.value = N; els.N.disabled = true; } else els.N.disabled = false;
 
+      const roles = Array.from(els.roleInputs.querySelectorAll('.role-row')).map(row => ({
+        id: row.dataset.id,
+        name: row.querySelector('.role-name').value,
+        base: toNum(row.querySelector('.role-base').value),
+      }));
+
       const data = computeCore.compute({
         C,
         kMax,
-        baseDoc,
-        baseNurse,
-        baseAssist,
+        roles,
         shiftH,
         monthH,
         n1,
@@ -391,23 +440,18 @@ if (toggle) {
         charts.s.update();
       }
 
-      els.baseDocCell.textContent = money(data.base_rates.doctor);
-      els.kDocCell.textContent = data.K_zona.toFixed(2);
-      els.finalDocCell.textContent = money(data.final_rates.doctor);
-      els.shiftDocCell.textContent = money(data.shift_salary.doctor);
-      els.monthDocCell.textContent = money(data.month_salary.doctor);
-
-      els.baseNurseCell.textContent = money(data.base_rates.nurse);
-      els.kNurseCell.textContent = data.K_zona.toFixed(2);
-      els.finalNurseCell.textContent = money(data.final_rates.nurse);
-      els.shiftNurseCell.textContent = money(data.shift_salary.nurse);
-      els.monthNurseCell.textContent = money(data.month_salary.nurse);
-
-      els.baseAssistCell.textContent = money(data.base_rates.assistant);
-      els.kAssistCell.textContent = data.K_zona.toFixed(2);
-      els.finalAssistCell.textContent = money(data.final_rates.assistant);
-      els.shiftAssistCell.textContent = money(data.shift_salary.assistant);
-      els.monthAssistCell.textContent = money(data.month_salary.assistant);
+      els.roleRatesBody.innerHTML = '';
+      roles.forEach(r => {
+        const tr = document.createElement('tr');
+        const id = r.id;
+        tr.innerHTML = `<td>${r.name}</td>`+
+          `<td>${money(data.base_rates[id])}</td>`+
+          `<td>${data.K_zona.toFixed(2)}</td>`+
+          `<td class="accent">${money(data.final_rates[id])}</td>`+
+          `<td>${money(data.shift_salary[id])}</td>`+
+          `<td>${money(data.month_salary[id])}</td>`;
+        els.roleRatesBody.appendChild(tr);
+      });
 
       return {
         date: els.date.value || null,
@@ -416,6 +460,7 @@ if (toggle) {
         zone_label: (ZONES.find(z=>z.id===els.zone.value)?.name) || els.zone.value,
         capacity: C,
         ...data,
+        roles: roles.map(r=>({ id: r.id, name: r.name }))
       };
     }
 
@@ -426,83 +471,16 @@ function resetAll(){
       els.N.value = 0; els.kmax.value = 1.30; els.linkN.checked = true;
       els.shiftHours.value = 12; els.monthHours.value = 0;
       els.esi1.value = 0; els.esi2.value = 0; els.esi3.value = 0; els.esi4.value = 0; els.esi5.value = 0;
-      // bandome užkrauti tarifų šabloną
-      let rawRates;
-      try {
-        rawRates = localStorage.getItem(LS_RATE_KEY);
-      } catch (e) {
-        console.error('Failed to fetch base rates', e);
-        rawRates = null;
-      }
-
-      let rates;
-      try {
-        rates = rawRates ? JSON.parse(rawRates) : {};
-      } catch (e) {
-        console.error('Failed to parse base rates', e);
-        rates = {};
-      }
-
-      try {
-        els.baseRateDoc.value = rates.doc ?? 0;
-        els.baseRateNurse.value = rates.nurse ?? 0;
-        els.baseRateAssist.value = rates.assist ?? 0;
-      } catch (e) {
-        console.error('Failed to assign base rates', e);
-        els.baseRateDoc.value = 0;
-        els.baseRateNurse.value = 0;
-        els.baseRateAssist.value = 0;
-      }
+      renderRoleInputs();
+      loadRateTemplate();
       compute();
 }
 
 function downloadCsv(){
   const data = compute();
-  const rows = [
-    ['date', data.date],
-    ['shift', data.shift],
-    ['zone', data.zone],
-    ['zone_label', data.zone_label],
-    ['capacity', data.capacity],
-    ['N', data.N],
-    ['ESI1', data.ESI.n1],
-    ['ESI2', data.ESI.n2],
-    ['ESI3', data.ESI.n3],
-    ['ESI4', data.ESI.n4],
-    ['ESI5', data.ESI.n5],
-    ['ratio', data.ratio],
-    ['S', data.S],
-    ['V_bonus', data.V_bonus],
-    ['A_bonus', data.A_bonus],
-    ['K_max', data.K_max],
-    ['K_zona', data.K_zona],
-    ['shift_hours', data.shift_hours],
-    ['month_hours', data.month_hours],
-    ['base_rate_doctor', data.base_rates.doctor],
-    ['base_rate_nurse', data.base_rates.nurse],
-    ['base_rate_assistant', data.base_rates.assistant],
-    ['final_rate_doctor', data.final_rates.doctor],
-    ['final_rate_nurse', data.final_rates.nurse],
-    ['final_rate_assistant', data.final_rates.assistant],
-    ['shift_salary_doctor', data.shift_salary.doctor],
-    ['shift_salary_nurse', data.shift_salary.nurse],
-    ['shift_salary_assistant', data.shift_salary.assistant],
-    ['month_salary_doctor', data.month_salary.doctor],
-    ['month_salary_nurse', data.month_salary.nurse],
-    ['month_salary_assistant', data.month_salary.assistant]
-  ];
-  function csvValue(val){
-    const safe = (val === null || val === undefined ? '' : String(val)).replace(/"/g, '""');
-    return `"${safe}"`;
-  }
-  const csv = (()=>{
-    if (typeof csvUtils !== 'undefined' && typeof csvUtils.rowsToCsv === 'function') {
-      return csvUtils.rowsToCsv(rows);
-    }
-    const headers = rows.map(r => r[0]).join(',');
-    const values = rows.map(r => csvValue(r[1])).join(',');
-    return `${headers}\n${values}`;
-  })();
+  const csv = (typeof csvUtils !== 'undefined' && typeof csvUtils.dataToCsv === 'function')
+    ? csvUtils.dataToCsv(data)
+    : '';
   const blob = new Blob([csv], { type: 'text/csv' });
   const url = URL.createObjectURL(blob);
   const a = document.createElement('a');
@@ -516,11 +494,32 @@ function downloadCsv(){
 
 // --- Įvykiai ---
     ['input','change'].forEach(evt => {
-      ['date','shift','zone','capacity','N','kmax','shiftHours','monthHours','baseRateDoc','baseRateNurse','baseRateAssist','linkN','esi1','esi2','esi3','esi4','esi5'].forEach(id => {
+      ['date','shift','zone','capacity','N','kmax','shiftHours','monthHours','linkN','esi1','esi2','esi3','esi4','esi5'].forEach(id => {
         const el = els[id];
         if (el) el.addEventListener(evt, compute);
       });
     });
+    els.roleInputs.addEventListener('input', e => {
+      if (e.target.classList.contains('role-name')) {
+        const row = e.target.closest('.role-row');
+        const role = ROLES.find(r => r.id === row.dataset.id);
+        if (role) { role.name = e.target.value; saveRoles(ROLES); }
+        compute();
+      } else if (e.target.classList.contains('role-base')) {
+        compute();
+      }
+    });
+    els.roleInputs.addEventListener('click', e => {
+      if (e.target.classList.contains('remove-role')) {
+        const row = e.target.closest('.role-row');
+        ROLES = ROLES.filter(r => r.id !== row.dataset.id);
+        saveRoles(ROLES);
+        renderRoleInputs();
+        loadRateTemplate();
+        compute();
+      }
+    });
+    els.addRole.addEventListener('click', (e)=>{ e.preventDefault(); addRole(); });
     els.shift.addEventListener('change', setDefaultCapacity);
     els.zone.addEventListener('change', setDefaultCapacity);
     els.reset.addEventListener('click', (e)=>{ e.preventDefault(); resetAll(); });

--- a/compute.js
+++ b/compute.js
@@ -27,9 +27,7 @@ function sanitize(value) {
 function compute({
   C,
   kMax,
-  baseDoc,
-  baseNurse,
-  baseAssist,
+  roles = [],
   shiftH,
   monthH,
   n1,
@@ -58,17 +56,19 @@ function compute({
   const A = getBonus(S, thresholds.A_BONUS || THRESHOLDS.A_BONUS);
   const K = Math.max(0, Math.min(1 + V + A, k));
 
-  const finalDoc = Math.max(0, baseDoc * K);
-  const finalNurse = Math.max(0, baseNurse * K);
-  const finalAssist = Math.max(0, baseAssist * K);
+  const baseRates = {};
+  const finalRates = {};
+  const shiftSalary = {};
+  const monthSalary = {};
 
-  const shiftDoc = finalDoc * sh;
-  const shiftNurse = finalNurse * sh;
-  const shiftAssist = finalAssist * sh;
-
-  const monthDoc = finalDoc * mh;
-  const monthNurse = finalNurse * mh;
-  const monthAssist = finalAssist * mh;
+  for (const r of roles) {
+    const base = sanitize(r.base);
+    const final = Math.max(0, base * K);
+    baseRates[r.id] = base;
+    finalRates[r.id] = final;
+    shiftSalary[r.id] = final * sh;
+    monthSalary[r.id] = final * mh;
+  }
 
   return {
     N: totalN,
@@ -81,26 +81,10 @@ function compute({
     K_zona: K,
     shift_hours: sh,
     month_hours: mh,
-    base_rates: {
-      doctor: baseDoc,
-      nurse: baseNurse,
-      assistant: baseAssist,
-    },
-    final_rates: {
-      doctor: finalDoc,
-      nurse: finalNurse,
-      assistant: finalAssist,
-    },
-    shift_salary: {
-      doctor: shiftDoc,
-      nurse: shiftNurse,
-      assistant: shiftAssist,
-    },
-    month_salary: {
-      doctor: monthDoc,
-      nurse: monthNurse,
-      assistant: monthAssist,
-    },
+    base_rates: baseRates,
+    final_rates: finalRates,
+    shift_salary: shiftSalary,
+    month_salary: monthSalary,
   };
 }
 

--- a/csv.js
+++ b/csv.js
@@ -10,7 +10,117 @@ function rowsToCsv(rows) {
   return `${headers}\n${values}`;
 }
 
-const exported = { rowsToCsv };
+function dataToCsv(data) {
+  const rows = [
+    ['date', data.date],
+    ['shift', data.shift],
+    ['zone', data.zone],
+    ['zone_label', data.zone_label],
+    ['capacity', data.capacity],
+    ['N', data.N],
+    ['ESI1', data.ESI.n1],
+    ['ESI2', data.ESI.n2],
+    ['ESI3', data.ESI.n3],
+    ['ESI4', data.ESI.n4],
+    ['ESI5', data.ESI.n5],
+    ['ratio', data.ratio],
+    ['S', data.S],
+    ['V_bonus', data.V_bonus],
+    ['A_bonus', data.A_bonus],
+    ['K_max', data.K_max],
+    ['K_zona', data.K_zona],
+    ['shift_hours', data.shift_hours],
+    ['month_hours', data.month_hours],
+  ];
+
+  if (Array.isArray(data.roles)) {
+    for (const r of data.roles) {
+      const id = r.id;
+      rows.push([`base_rate_${id}`, data.base_rates[id]]);
+      rows.push([`final_rate_${id}`, data.final_rates[id]]);
+      rows.push([`shift_salary_${id}`, data.shift_salary[id]]);
+      rows.push([`month_salary_${id}`, data.month_salary[id]]);
+    }
+  }
+
+  return rowsToCsv(rows);
+}
+
+function parseCsvLine(line) {
+  const result = [];
+  let current = '';
+  let inQuotes = false;
+  for (let i = 0; i < line.length; i++) {
+    const char = line[i];
+    if (inQuotes) {
+      if (char === '"') {
+        if (i + 1 < line.length && line[i + 1] === '"') {
+          current += '"';
+          i++;
+        } else {
+          inQuotes = false;
+        }
+      } else {
+        current += char;
+      }
+    } else {
+      if (char === '"') {
+        inQuotes = true;
+      } else if (char === ',') {
+        result.push(current);
+        current = '';
+      } else {
+        current += char;
+      }
+    }
+  }
+  result.push(current);
+  return result;
+}
+
+function csvToData(csv) {
+  const [headerLine, valueLine] = csv.trim().split(/\r?\n/);
+  const headers = parseCsvLine(headerLine);
+  const values = parseCsvLine(valueLine);
+  const data = {
+    ESI: {},
+    base_rates: {},
+    final_rates: {},
+    shift_salary: {},
+    month_salary: {},
+    roles: [],
+  };
+  for (let i = 0; i < headers.length; i++) {
+    const key = headers[i];
+    const val = values[i];
+    if (key.startsWith('ESI')) {
+      data.ESI[`n${key.slice(3)}`] = Number(val);
+    } else if (key.startsWith('base_rate_')) {
+      const id = key.replace('base_rate_', '');
+      data.base_rates[id] = Number(val);
+      if (!data.roles.find(r => r.id === id)) data.roles.push({ id });
+    } else if (key.startsWith('final_rate_')) {
+      const id = key.replace('final_rate_', '');
+      data.final_rates[id] = Number(val);
+      if (!data.roles.find(r => r.id === id)) data.roles.push({ id });
+    } else if (key.startsWith('shift_salary_')) {
+      const id = key.replace('shift_salary_', '');
+      data.shift_salary[id] = Number(val);
+      if (!data.roles.find(r => r.id === id)) data.roles.push({ id });
+    } else if (key.startsWith('month_salary_')) {
+      const id = key.replace('month_salary_', '');
+      data.month_salary[id] = Number(val);
+      if (!data.roles.find(r => r.id === id)) data.roles.push({ id });
+    } else if (key === 'date' || key === 'shift' || key === 'zone' || key === 'zone_label') {
+      data[key] = val;
+    } else if (key === 'capacity' || key === 'N' || key === 'ratio' || key === 'S' || key === 'V_bonus' || key === 'A_bonus' || key === 'K_max' || key === 'K_zona' || key === 'shift_hours' || key === 'month_hours') {
+      data[key] = Number(val);
+    }
+  }
+  return data;
+}
+
+const exported = { rowsToCsv, dataToCsv, csvToData };
 
 if (typeof module !== 'undefined') {
   module.exports = exported;

--- a/index.html
+++ b/index.html
@@ -71,29 +71,15 @@
           </div>
         </div>
 
-        <div class="row">
-          <div>
-            <label for="baseRateDoc">Bazinis gydytojo tarifas (€ / val.)</label>
-            <input id="baseRateDoc" type="number" min="0" step="0.01" value="0" placeholder="pvz. 25.00" />
+        <div id="rolesBlock">
+          <label>Rolės ir baziniai tarifai</label>
+          <div id="roleInputs"></div>
+          <div class="actions">
+            <button id="addRole">+ Pridėti rolę</button>
+            <button id="saveRateTemplate">Įsiminti tarifų šabloną</button>
+            <button id="loadRateTemplate">Užkrauti šabloną</button>
           </div>
-          <div>
-            <label for="baseRateNurse">Bazinis slaugytojo tarifas (€ / val.)</label>
-            <input id="baseRateNurse" type="number" min="0" step="0.01" value="0" placeholder="pvz. 14.00" />
-          </div>
-        </div>
-        <div class="row">
-          <div>
-            <label for="baseRateAssist">Bazinis padėjėjo tarifas (€ / val.)</label>
-            <input id="baseRateAssist" type="number" min="0" step="0.01" value="0" placeholder="pvz. 9.00" />
-          </div>
-          <div>
-            <label>&nbsp;</label>
-            <div class="actions">
-              <button id="saveRateTemplate">Įsiminti tarifų šabloną</button>
-              <button id="loadRateTemplate">Užkrauti šabloną</button>
-            </div>
-            <div class="help">Tarifų šablonas saugomas vietoje (localStorage).</div>
-          </div>
+          <div class="help">Tarifų šablonas saugomas vietoje (localStorage).</div>
         </div>
 
         <div class="switch-block">
@@ -195,11 +181,7 @@
           <thead>
             <tr><th>Rolė</th><th>Bazė (€/val.)</th><th>Koef. K<sub>zona</sub></th><th>Galutinis (€/val.)</th><th>Pam. alga (€/pam.)</th><th>Mėn. alga (€/mėn.)</th></tr>
           </thead>
-          <tbody>
-            <tr><td>Gydytojas</td><td id="baseDocCell">€0,00</td><td id="kDocCell">1,00</td><td class="accent" id="finalDocCell">€0,00</td><td id="shiftDocCell">€0,00</td><td id="monthDocCell">€0,00</td></tr>
-            <tr><td>Slaugytojas</td><td id="baseNurseCell">€0,00</td><td id="kNurseCell">1,00</td><td class="accent" id="finalNurseCell">€0,00</td><td id="shiftNurseCell">€0,00</td><td id="monthNurseCell">€0,00</td></tr>
-            <tr><td>Padėjėjas</td><td id="baseAssistCell">€0,00</td><td id="kAssistCell">1,00</td><td class="accent" id="finalAssistCell">€0,00</td><td id="shiftAssistCell">€0,00</td><td id="monthAssistCell">€0,00</td></tr>
-          </tbody>
+          <tbody id="roleRatesBody"></tbody>
         </table>
 
         <div class="footer">

--- a/tests/compute.test.js
+++ b/tests/compute.test.js
@@ -6,9 +6,11 @@ describe('compute core logic', () => {
       C: 100,
       N: 50,
       kMax: 1.3,
-      baseDoc: 10,
-      baseNurse: 10,
-      baseAssist: 10,
+      roles: [
+        { id: 'doctor', base: 10 },
+        { id: 'nurse', base: 10 },
+        { id: 'assistant', base: 10 },
+      ],
       shiftH: 0,
       monthH: 0,
       n1: 10,
@@ -27,9 +29,11 @@ describe('compute core logic', () => {
       C: 80,
       N: 100,
       kMax: 1.3,
-      baseDoc: 10,
-      baseNurse: 10,
-      baseAssist: 10,
+      roles: [
+        { id: 'doctor', base: 10 },
+        { id: 'nurse', base: 10 },
+        { id: 'assistant', base: 10 },
+      ],
       shiftH: 0,
       monthH: 0,
       n1: 10,
@@ -47,9 +51,11 @@ describe('compute core logic', () => {
     const result = compute({
       C: 70,
       kMax: 1.3,
-      baseDoc: 10,
-      baseNurse: 10,
-      baseAssist: 10,
+      roles: [
+        { id: 'doctor', base: 10 },
+        { id: 'nurse', base: 10 },
+        { id: 'assistant', base: 10 },
+      ],
       shiftH: 0,
       monthH: 0,
       n1: 15,
@@ -69,9 +75,11 @@ describe('compute core logic', () => {
       C: 80,
       N: 120,
       kMax: 1.3,
-      baseDoc: 10,
-      baseNurse: 10,
-      baseAssist: 10,
+      roles: [
+        { id: 'doctor', base: 10 },
+        { id: 'nurse', base: 10 },
+        { id: 'assistant', base: 10 },
+      ],
       shiftH: 0,
       monthH: 0,
       n1: 20,
@@ -90,9 +98,11 @@ describe('compute core logic', () => {
       C: NaN,
       N: NaN,
       kMax: NaN,
-      baseDoc: 10,
-      baseNurse: 10,
-      baseAssist: 10,
+      roles: [
+        { id: 'doctor', base: 10 },
+        { id: 'nurse', base: 10 },
+        { id: 'assistant', base: 10 },
+      ],
       shiftH: NaN,
       monthH: NaN,
       n1: NaN,
@@ -112,9 +122,11 @@ describe('compute core logic', () => {
       C: -100,
       N: -50,
       kMax: -1,
-      baseDoc: 10,
-      baseNurse: 10,
-      baseAssist: 10,
+      roles: [
+        { id: 'doctor', base: 10 },
+        { id: 'nurse', base: 10 },
+        { id: 'assistant', base: 10 },
+      ],
       shiftH: -10,
       monthH: -160,
       n1: -5,
@@ -134,9 +146,11 @@ describe('compute core logic', () => {
       C: Infinity,
       N: Infinity,
       kMax: Infinity,
-      baseDoc: 10,
-      baseNurse: 10,
-      baseAssist: 10,
+      roles: [
+        { id: 'doctor', base: 10 },
+        { id: 'nurse', base: 10 },
+        { id: 'assistant', base: 10 },
+      ],
       shiftH: Infinity,
       monthH: Infinity,
       n1: Infinity,
@@ -168,9 +182,11 @@ describe('compute core logic', () => {
       C: 100,
       N: 150,
       kMax: 2,
-      baseDoc: 10,
-      baseNurse: 10,
-      baseAssist: 10,
+      roles: [
+        { id: 'doctor', base: 10 },
+        { id: 'nurse', base: 10 },
+        { id: 'assistant', base: 10 },
+      ],
       shiftH: 0,
       monthH: 0,
       n1: 30,
@@ -182,5 +198,28 @@ describe('compute core logic', () => {
     expect(result.V_bonus).toBe(0.4);
     expect(result.A_bonus).toBe(0.1);
     expect(result.K_zona).toBeCloseTo(1.5);
+  });
+
+  test('computes salaries for multiple roles', () => {
+    const result = compute({
+      C: 50,
+      N: 50,
+      kMax: 2,
+      roles: [
+        { id: 'doc', base: 10 },
+        { id: 'nurse', base: 20 },
+      ],
+      shiftH: 10,
+      monthH: 100,
+      n1: 10,
+      n2: 10,
+      n3: 30,
+      n4: 0,
+      n5: 0,
+    });
+    expect(result.final_rates.doc).toBeCloseTo(10 * result.K_zona);
+    expect(result.final_rates.nurse).toBeCloseTo(20 * result.K_zona);
+    expect(result.shift_salary.nurse).toBeCloseTo(result.final_rates.nurse * 10);
+    expect(result.month_salary.doc).toBeCloseTo(result.final_rates.doc * 100);
   });
 });

--- a/tests/csv.test.js
+++ b/tests/csv.test.js
@@ -1,4 +1,4 @@
-const { rowsToCsv } = require('../csv');
+const { rowsToCsv, dataToCsv, csvToData } = require('../csv');
 
 function parseCsvLine(line) {
   const result = [];
@@ -103,4 +103,36 @@ test('csv remains valid when zone_label has commas and quotes', () => {
   const csv = rowsToCsv(rows);
   const values = parseCsvLine(csv.split('\n')[1]);
   expect(values).toEqual(['Critical, "Red" Zone', '20']);
+});
+
+test('round trips data with multiple roles', () => {
+  const data = {
+    date: '2024-01-01',
+    shift: 'D',
+    zone: 'RED',
+    zone_label: 'Red',
+    capacity: 20,
+    N: 10,
+    ESI: { n1: 1, n2: 2, n3: 3, n4: 4, n5: 0 },
+    ratio: 0.5,
+    S: 0.3,
+    V_bonus: 0.1,
+    A_bonus: 0.05,
+    K_max: 1.3,
+    K_zona: 1.15,
+    shift_hours: 8,
+    month_hours: 160,
+    roles: [{ id: 'doc' }, { id: 'nurse' }],
+    base_rates: { doc: 1, nurse: 2 },
+    final_rates: { doc: 1.1, nurse: 2.2 },
+    shift_salary: { doc: 8.8, nurse: 17.6 },
+    month_salary: { doc: 176, nurse: 352 },
+  };
+
+  const csv = dataToCsv(data);
+  const parsed = csvToData(csv);
+  expect(parsed.base_rates.doc).toBe(1);
+  expect(parsed.base_rates.nurse).toBe(2);
+  expect(parsed.roles.find(r => r.id === 'doc')).toBeTruthy();
+  expect(parsed.roles.find(r => r.id === 'nurse')).toBeTruthy();
 });


### PR DESCRIPTION
## Summary
- allow calculator core to compute salaries for any set of roles
- render roles dynamically with add/remove and persist definitions
- export/import CSV data with dynamic role columns

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b42a4bea248320bb79904618e6cab5