### PR TITLE
test: cover multi-role scenarios

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,13 @@ npm test
 
 Role definitions are editable and persisted in your browser's `localStorage`. Use the **+ Pridėti rolę** button to add positions or remove existing ones. Base rate templates save and load values for all defined roles.
 
+## CSV Export and Import
+
+Downloading results as CSV will include a set of columns for every defined role:
+`base_rate_<role>`, `final_rate_<role>`, `shift_salary_<role>` and
+`month_salary_<role>`. The parser reconstructs the role list from these
+columns, allowing data to round‑trip through the CSV format even as roles are added or removed.
+
 ## Adjusting Bonus Thresholds
 
 The calculator allows customizing the occupancy (V) and acuity (A) bonus thresholds. Click **Redaguoti priedus** in the interface to open a modal where you can edit the `V_BONUS` and `A_BONUS` arrays in JSON form. Saved thresholds persist in your browser's `localStorage` under the key `ED_THRESHOLDS`.

--- a/tests/compute.test.js
+++ b/tests/compute.test.js
@@ -222,4 +222,29 @@ describe('compute core logic', () => {
     expect(result.shift_salary.nurse).toBeCloseTo(result.final_rates.nurse * 10);
     expect(result.month_salary.doc).toBeCloseTo(result.final_rates.doc * 100);
   });
+
+  test('supports three distinct roles', () => {
+    const result = compute({
+      C: 60,
+      N: 60,
+      kMax: 1.5,
+      roles: [
+        { id: 'a', base: 5 },
+        { id: 'b', base: 10 },
+        { id: 'c', base: 15 },
+      ],
+      shiftH: 8,
+      monthH: 40,
+      n1: 5,
+      n2: 5,
+      n3: 50,
+      n4: 0,
+      n5: 0,
+    });
+    expect(result.final_rates.a).toBeCloseTo(5 * result.K_zona);
+    expect(result.final_rates.b).toBeCloseTo(10 * result.K_zona);
+    expect(result.final_rates.c).toBeCloseTo(15 * result.K_zona);
+    expect(Object.keys(result.final_rates)).toEqual(['a', 'b', 'c']);
+    expect(result.shift_salary.c).toBeCloseTo(result.final_rates.c * 8);
+  });
 });

--- a/tests/csv.test.js
+++ b/tests/csv.test.js
@@ -122,17 +122,19 @@ test('round trips data with multiple roles', () => {
     K_zona: 1.15,
     shift_hours: 8,
     month_hours: 160,
-    roles: [{ id: 'doc' }, { id: 'nurse' }],
-    base_rates: { doc: 1, nurse: 2 },
-    final_rates: { doc: 1.1, nurse: 2.2 },
-    shift_salary: { doc: 8.8, nurse: 17.6 },
-    month_salary: { doc: 176, nurse: 352 },
+    roles: [{ id: 'doc' }, { id: 'nurse' }, { id: 'assistant' }],
+    base_rates: { doc: 1, nurse: 2, assistant: 3 },
+    final_rates: { doc: 1.1, nurse: 2.2, assistant: 3.3 },
+    shift_salary: { doc: 8.8, nurse: 17.6, assistant: 26.4 },
+    month_salary: { doc: 176, nurse: 352, assistant: 528 },
   };
 
   const csv = dataToCsv(data);
   const parsed = csvToData(csv);
   expect(parsed.base_rates.doc).toBe(1);
   expect(parsed.base_rates.nurse).toBe(2);
+  expect(parsed.base_rates.assistant).toBe(3);
   expect(parsed.roles.find(r => r.id === 'doc')).toBeTruthy();
   expect(parsed.roles.find(r => r.id === 'nurse')).toBeTruthy();
+  expect(parsed.roles.find(r => r.id === 'assistant')).toBeTruthy();
 });


### PR DESCRIPTION
## Summary
- add coverage for three-role salary calculations
- ensure CSV round trips with arbitrary roles
- document dynamic CSV columns in README

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b49250e724832088afc325de01b208