### PR TITLE
Use csvUtils helper for CSV export

### DIFF
--- a/app.js
+++ b/app.js
@@ -407,18 +407,7 @@ function downloadCsv(){
     ['month_salary_nurse', data.month_salary.nurse],
     ['month_salary_assistant', data.month_salary.assistant]
   ];
-  function csvValue(val){
-    const safe = (val === null || val === undefined ? '' : String(val)).replace(/"/g, '""');
-    return `"${safe}"`;
-  }
-  const csv = (()=>{
-    if (typeof csvUtils !== 'undefined' && typeof csvUtils.rowsToCsv === 'function') {
-      return csvUtils.rowsToCsv(rows);
-    }
-    const headers = rows.map(r => r[0]).join(',');
-    const values = rows.map(r => csvValue(r[1])).join(',');
-    return `${headers}\n${values}`;
-  })();
+  const csv = csvUtils.rowsToCsv(rows);
   const blob = new Blob([csv], { type: 'text/csv' });
   const url = URL.createObjectURL(blob);
   const a = document.createElement('a');


### PR DESCRIPTION
## Summary
- Simplify CSV export by delegating to `csvUtils.rowsToCsv` directly in `downloadCsv`
- Rely on `csv.js` being loaded before `app.js` for CSV utilities

## Testing
- `CI=true npm test`
- `node -e "const { rowsToCsv } = require('./csv'); console.log(rowsToCsv([['zone_label', 'Critical, \"Red\" Zone'], ['capacity', 20]]));"`


------
https://chatgpt.com/codex/tasks/task_e_68b59e2e1c308320b2d9e53705cf3b47