### PR TITLE
Auto-set 24h duration for paros shift

### DIFF
--- a/app.js
+++ b/app.js
@@ -178,16 +178,26 @@ if (toggle) {
       setDefaultCapacity();
     }
 
-    function setDefaultCapacity(){
-      const id = els.zone.value; const s = els.shift.value;
-      const z = ZONES.find(x=>x.id===id);
-      const cap = z ? (
-        s === 'D' ? (z.cap?.D ?? 20) :
-        s === 'N' ? (z.cap?.N ?? 16) :
-        (z.cap?.P ?? ((z.cap?.D ?? 20) + (z.cap?.N ?? 16)))
-      ) : 20;
-      els.capacity.value = cap;
-    }
+function setDefaultCapacity(){
+  const id = els.zone.value; const s = els.shift.value;
+  const z = ZONES.find(x=>x.id===id);
+  const cap = z ? (
+    s === 'D' ? (z.cap?.D ?? 20) :
+    s === 'N' ? (z.cap?.N ?? 16) :
+    (z.cap?.P ?? ((z.cap?.D ?? 20) + (z.cap?.N ?? 16)))
+  ) : 20;
+  els.capacity.value = cap;
+}
+
+function handleShiftChange(){
+  setDefaultCapacity();
+  if (els.shift.value === 'P') {
+    els.shiftHours.value = 24;
+  } else if (toNum(els.shiftHours.value) === 24) {
+    els.shiftHours.value = 12;
+  }
+  compute();
+}
 
     function openZoneModal(){ els.zoneModal.classList.add('active'); renderZoneEditor(); }
     function closeZoneModal(){ els.zoneModal.classList.remove('active'); }
@@ -426,14 +436,14 @@ function downloadCsv(){
 }
 
 // --- Įvykiai ---
-    ['input','change'].forEach(evt => {
-      ['date','shift','zone','capacity','N','kmax','shiftHours','monthHours','baseRateDoc','baseRateNurse','baseRateAssist','linkN','esi1','esi2','esi3','esi4','esi5'].forEach(id => {
-        const el = els[id];
-        if (el) el.addEventListener(evt, compute);
-      });
-    });
-    els.shift.addEventListener('change', setDefaultCapacity);
-    els.zone.addEventListener('change', setDefaultCapacity);
+['input','change'].forEach(evt => {
+  ['date','zone','capacity','N','kmax','shiftHours','monthHours','baseRateDoc','baseRateNurse','baseRateAssist','linkN','esi1','esi2','esi3','esi4','esi5'].forEach(id => {
+    const el = els[id];
+    if (el) el.addEventListener(evt, compute);
+  });
+});
+els.shift.addEventListener('change', handleShiftChange);
+els.zone.addEventListener('change', setDefaultCapacity);
     els.reset.addEventListener('click', (e)=>{ e.preventDefault(); resetAll(); });
     els.copy.addEventListener('click', (e)=>{
       e.preventDefault();


### PR DESCRIPTION
## Summary
- Automatically set shift duration to 24 hours when the "Paros" (24h) shift is selected and reset to 12 when leaving
- Hook shift selector to new handler and update change listeners

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b5a84b75b8832093a1263c0dca88db