### PR TITLE
Add PDF export using jsPDF

### DIFF
--- a/app.js
+++ b/app.js
@@ -103,6 +103,7 @@ if (toggle) {
       reset: document.getElementById('reset'),
       copy: document.getElementById('copy'),
       downloadCsv: document.getElementById('downloadCsv'),
+      downloadPdf: document.getElementById('downloadPdf'),
       manageZones: document.getElementById('manageZones'),
       zoneModal: document.getElementById('zoneModal'),
       zoneTbody: document.getElementById('zoneTbody'),
@@ -435,6 +436,12 @@ function downloadCsv(){
   URL.revokeObjectURL(url);
 }
 
+function downloadPdf(){
+  const data = compute();
+  const doc = pdfUtils.generatePdf(data);
+  doc.save('salary_calc.pdf');
+}
+
 // --- Įvykiai ---
 ['input','change'].forEach(evt => {
   ['date','zone','capacity','N','kmax','shiftHours','monthHours','baseRateDoc','baseRateNurse','baseRateAssist','linkN','esi1','esi2','esi3','esi4','esi5'].forEach(id => {
@@ -445,7 +452,7 @@ function downloadCsv(){
 els.shift.addEventListener('change', handleShiftChange);
 els.zone.addEventListener('change', setDefaultCapacity);
     els.reset.addEventListener('click', (e)=>{ e.preventDefault(); resetAll(); });
-    els.copy.addEventListener('click', (e)=>{
+      els.copy.addEventListener('click', (e)=>{
       e.preventDefault();
       const payload = compute();
       const txt = JSON.stringify(payload, null, 2);
@@ -456,7 +463,8 @@ els.zone.addEventListener('change', setDefaultCapacity);
         alert('Nepavyko nukopijuoti. Pažymėkite ir kopijuokite rankiniu būdu.');
       });
     });
-    els.downloadCsv.addEventListener('click', (e)=>{ e.preventDefault(); downloadCsv(); });
+      els.downloadCsv.addEventListener('click', (e)=>{ e.preventDefault(); downloadCsv(); });
+      els.downloadPdf.addEventListener('click', (e)=>{ e.preventDefault(); downloadPdf(); });
 
     // Zonų modalas
     els.manageZones.addEventListener('click', openZoneModal);

--- a/index.html
+++ b/index.html
@@ -134,11 +134,12 @@
         </div>
 
 
-        <div class="actions">
-          <button class="primary" id="reset">Išvalyti</button>
-          <button id="copy">Kopijuoti rezultatą (JSON)</button>
-          <button id="downloadCsv">Download CSV</button>
-        </div>
+          <div class="actions">
+            <button class="primary" id="reset">Išvalyti</button>
+            <button id="copy">Kopijuoti rezultatą (JSON)</button>
+            <button id="downloadCsv">Download CSV</button>
+            <button id="downloadPdf">Download PDF</button>
+          </div>
       </div>
 
       <div class="card">
@@ -240,9 +241,11 @@
     </div>
   </div>
 
-  <script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
-  <script src="compute.js" defer></script>
-  <script src="csv.js" defer></script>
-  <script src="app.js" defer></script>
+    <script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/jspdf@2.5.1/dist/jspdf.umd.min.js"></script>
+    <script src="compute.js" defer></script>
+    <script src="csv.js" defer></script>
+    <script src="pdf.js" defer></script>
+    <script src="app.js" defer></script>
 </body>
 </html>

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,9 @@
       "name": "salary-calculator",
       "version": "1.0.0",
       "license": "ISC",
+      "dependencies": {
+        "jspdf": "^2.5.1"
+      },
       "devDependencies": {
         "jest": "^30.1.1"
       }
@@ -465,6 +468,15 @@
       },
       "peerDependencies": {
         "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/runtime": {
+      "version": "7.28.3",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.28.3.tgz",
+      "integrity": "sha512-9uIQ10o0WGdpP6GDhXcdOJPJuDgFtIDtN/9+ArJQ2NAfAmiuhTQdzkaTGR33v43GYS2UrSA0eX2pPPHoFVvpxA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/template": {
@@ -1139,6 +1151,13 @@
         "undici-types": "~7.10.0"
       }
     },
+    "node_modules/@types/raf": {
+      "version": "3.4.3",
+      "resolved": "https://registry.npmjs.org/@types/raf/-/raf-3.4.3.tgz",
+      "integrity": "sha512-c4YAvMedbPZ5tEyxzQdMoOhhJ4RD3rngZIdwC2/qDN3d7JpEhB6fiBRKVY1lg5B7Wk+uPBjn5f39j1/2MY1oOw==",
+      "license": "MIT",
+      "optional": true
+    },
     "node_modules/@types/stack-utils": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/@types/stack-utils/-/stack-utils-2.0.3.tgz",
@@ -1508,6 +1527,18 @@
         "sprintf-js": "~1.0.2"
       }
     },
+    "node_modules/atob": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/atob/-/atob-2.1.2.tgz",
+      "integrity": "sha512-Wm6ukoaOGJi/73p/cl2GvLjTI5JM1k/O14isD73YML8StrH/7/lRFgmg8nICZgD3bZZvjwCGxtMOD3wWNAu8cg==",
+      "license": "(MIT OR Apache-2.0)",
+      "bin": {
+        "atob": "bin/atob.js"
+      },
+      "engines": {
+        "node": ">= 4.5.0"
+      }
+    },
     "node_modules/babel-jest": {
       "version": "30.1.1",
       "resolved": "https://registry.npmjs.org/babel-jest/-/babel-jest-30.1.1.tgz",
@@ -1613,6 +1644,16 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/base64-arraybuffer": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/base64-arraybuffer/-/base64-arraybuffer-1.0.2.tgz",
+      "integrity": "sha512-I3yl4r9QB5ZRY3XuJVEPfc2XhZO6YweFPI+UovAzn+8/hb3oJ6lnysaFcjVpkCPfVWFUDvoZ8kmVDP7WyRtYtQ==",
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">= 0.6.0"
+      }
+    },
     "node_modules/brace-expansion": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.2.tgz",
@@ -1679,6 +1720,18 @@
         "node-int64": "^0.4.0"
       }
     },
+    "node_modules/btoa": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/btoa/-/btoa-1.2.1.tgz",
+      "integrity": "sha512-SB4/MIGlsiVkMcHmT+pSmIPoNDoHg+7cMzmt3Uxt628MTz2487DKSqK/fuhFBrkuqrYv5UCEnACpF4dTFNKc/g==",
+      "license": "(MIT OR Apache-2.0)",
+      "bin": {
+        "btoa": "bin/btoa.js"
+      },
+      "engines": {
+        "node": ">= 0.4.0"
+      }
+    },
     "node_modules/buffer-from": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.2.tgz",
@@ -1726,6 +1779,26 @@
         }
       ],
       "license": "CC-BY-4.0"
+    },
+    "node_modules/canvg": {
+      "version": "3.0.11",
+      "resolved": "https://registry.npmjs.org/canvg/-/canvg-3.0.11.tgz",
+      "integrity": "sha512-5ON+q7jCTgMp9cjpu4Jo6XbvfYwSB2Ow3kzHKfIyJfaCAOHLbdKPQqGKgfED/R5B+3TFFfe8pegYA+b423SRyA==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@babel/runtime": "^7.12.5",
+        "@types/raf": "^3.4.0",
+        "core-js": "^3.8.3",
+        "raf": "^3.4.1",
+        "regenerator-runtime": "^0.13.7",
+        "rgbcolor": "^1.0.1",
+        "stackblur-canvas": "^2.0.0",
+        "svg-pathdata": "^6.0.3"
+      },
+      "engines": {
+        "node": ">=10.0.0"
+      }
     },
     "node_modules/chalk": {
       "version": "4.1.2",
@@ -1907,6 +1980,18 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/core-js": {
+      "version": "3.45.1",
+      "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.45.1.tgz",
+      "integrity": "sha512-L4NPsJlCfZsPeXukyzHFlg/i7IIVwHSItR0wg0FLNqYClJ4MQYTYLbC7EkjKYRLZF2iof2MUgN0EGy7MdQFChg==",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/core-js"
+      }
+    },
     "node_modules/cross-spawn": {
       "version": "7.0.6",
       "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
@@ -1920,6 +2005,16 @@
       },
       "engines": {
         "node": ">= 8"
+      }
+    },
+    "node_modules/css-line-break": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/css-line-break/-/css-line-break-2.1.0.tgz",
+      "integrity": "sha512-FHcKFCZcAha3LwfVBhCQbW2nCNbkZXn7KVUJcsT5/P8YmfsVja0FMPJr0B903j/E69HUphKiV9iQArX8SDYA4w==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "utrie": "^1.0.2"
       }
     },
     "node_modules/debug": {
@@ -1974,6 +2069,13 @@
       "engines": {
         "node": ">=8"
       }
+    },
+    "node_modules/dompurify": {
+      "version": "2.5.8",
+      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-2.5.8.tgz",
+      "integrity": "sha512-o1vSNgrmYMQObbSSvF/1brBYEQPHhV1+gsmrusO7/GXtp1T9rCS8cXFqVxK/9crT1jA6Ccv+5MTSjBNqr7Sovw==",
+      "license": "(MPL-2.0 OR Apache-2.0)",
+      "optional": true
     },
     "node_modules/eastasianwidth": {
       "version": "0.2.0",
@@ -2129,6 +2231,12 @@
         "bser": "2.1.1"
       }
     },
+    "node_modules/fflate": {
+      "version": "0.4.8",
+      "resolved": "https://registry.npmjs.org/fflate/-/fflate-0.4.8.tgz",
+      "integrity": "sha512-FJqqoDBR00Mdj9ppamLa/Y7vxm+PRmNWA67N846RvsoYVMKB4q3y/de5PA7gUmRMYK/8CMz2GDZQmCRN1wBcWA==",
+      "license": "MIT"
+    },
     "node_modules/fill-range": {
       "version": "7.1.1",
       "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.1.1.tgz",
@@ -2282,6 +2390,20 @@
       "integrity": "sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/html2canvas": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/html2canvas/-/html2canvas-1.4.1.tgz",
+      "integrity": "sha512-fPU6BHNpsyIhr8yyMpTLLxAbkaK8ArIBcmZIRiBLiDhjeqvXolaEmDGmELFuX9I4xDcaKKcJl+TKZLqruBbmWA==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "css-line-break": "^2.1.0",
+        "text-segmentation": "^1.0.3"
+      },
+      "engines": {
+        "node": ">=8.0.0"
+      }
     },
     "node_modules/human-signals": {
       "version": "2.1.0",
@@ -3159,6 +3281,24 @@
         "node": ">=6"
       }
     },
+    "node_modules/jspdf": {
+      "version": "2.5.1",
+      "resolved": "https://registry.npmjs.org/jspdf/-/jspdf-2.5.1.tgz",
+      "integrity": "sha512-hXObxz7ZqoyhxET78+XR34Xu2qFGrJJ2I2bE5w4SM8eFaFEkW2xcGRVUss360fYelwRSid/jT078kbNvmoW0QA==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.14.0",
+        "atob": "^2.1.2",
+        "btoa": "^1.2.1",
+        "fflate": "^0.4.8"
+      },
+      "optionalDependencies": {
+        "canvg": "^3.0.6",
+        "core-js": "^3.6.0",
+        "dompurify": "^2.2.0",
+        "html2canvas": "^1.0.0-rc.5"
+      }
+    },
     "node_modules/leven": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/leven/-/leven-3.1.0.tgz",
@@ -3523,6 +3663,13 @@
       "dev": true,
       "license": "ISC"
     },
+    "node_modules/performance-now": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/performance-now/-/performance-now-2.1.0.tgz",
+      "integrity": "sha512-7EAHlyLHI56VEIdK57uwHdHKIaAGbnXPiw0yWbarQZOKaKpvUIgW0jWRVLiatnM+XXlSwsanIBH/hzGMJulMow==",
+      "license": "MIT",
+      "optional": true
+    },
     "node_modules/picocolors": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
@@ -3611,12 +3758,29 @@
       ],
       "license": "MIT"
     },
+    "node_modules/raf": {
+      "version": "3.4.1",
+      "resolved": "https://registry.npmjs.org/raf/-/raf-3.4.1.tgz",
+      "integrity": "sha512-Sq4CW4QhwOHE8ucn6J34MqtZCeWFP2aQSmrlroYgqAV1PjStIhJXxYuTgUIfkEk7zTLjmIjLmU5q+fbD1NnOJA==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "performance-now": "^2.1.0"
+      }
+    },
     "node_modules/react-is": {
       "version": "18.3.1",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-18.3.1.tgz",
       "integrity": "sha512-/LLMVyas0ljjAtoYiPqYiL8VWXzUUdThrmU5+n20DZv+a+ClRoevUzw5JxU+Ieh5/c87ytoTBV9G1FiKfNJdmg==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/regenerator-runtime": {
+      "version": "0.13.11",
+      "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.11.tgz",
+      "integrity": "sha512-kY1AZVr2Ra+t+piVaJ4gxaFaReZVH40AKNo7UCX6W+dEwBo/2oZJzqfuN1qLq1oL45o56cPaTXELwrTh8Fpggg==",
+      "license": "MIT",
+      "optional": true
     },
     "node_modules/require-directory": {
       "version": "2.1.1",
@@ -3649,6 +3813,16 @@
       "license": "MIT",
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/rgbcolor": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/rgbcolor/-/rgbcolor-1.0.1.tgz",
+      "integrity": "sha512-9aZLIrhRaD97sgVhtJOW6ckOEh6/GnvQtdVNfdZ6s67+3/XwLS9lBcQYzEEhYVeUowN7pRzMLsyGhK2i/xvWbw==",
+      "license": "MIT OR SEE LICENSE IN FEEL-FREE.md",
+      "optional": true,
+      "engines": {
+        "node": ">= 0.8.15"
       }
     },
     "node_modules/semver": {
@@ -3746,6 +3920,16 @@
       },
       "engines": {
         "node": ">=10"
+      }
+    },
+    "node_modules/stackblur-canvas": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/stackblur-canvas/-/stackblur-canvas-2.7.0.tgz",
+      "integrity": "sha512-yf7OENo23AGJhBriGx0QivY5JP6Y1HbrrDI6WLt6C5auYZXlQrheoY8hD4ibekFKz1HOfE48Ww8kMWMnJD/zcQ==",
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">=0.1.14"
       }
     },
     "node_modules/string-length": {
@@ -3935,6 +4119,16 @@
         "node": ">=8"
       }
     },
+    "node_modules/svg-pathdata": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/svg-pathdata/-/svg-pathdata-6.0.3.tgz",
+      "integrity": "sha512-qsjeeq5YjBZ5eMdFuUa4ZosMLxgr5RZ+F+Y1OrDhuOCEInRMA3x74XdBtggJcj9kOeInz0WE+LgCPDkZFlBYJw==",
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
     "node_modules/synckit": {
       "version": "0.11.11",
       "resolved": "https://registry.npmjs.org/synckit/-/synckit-0.11.11.tgz",
@@ -4010,6 +4204,16 @@
       },
       "engines": {
         "node": "*"
+      }
+    },
+    "node_modules/text-segmentation": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/text-segmentation/-/text-segmentation-1.0.3.tgz",
+      "integrity": "sha512-iOiPUo/BGnZ6+54OsWxZidGCsdU8YbE4PSpdPinp7DeMtUJNJBoJ/ouUSTJjHkh1KntHaltHl/gDs2FC4i5+Nw==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "utrie": "^1.0.2"
       }
     },
     "node_modules/tmpl": {
@@ -4134,6 +4338,16 @@
       },
       "peerDependencies": {
         "browserslist": ">= 4.21.0"
+      }
+    },
+    "node_modules/utrie": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/utrie/-/utrie-1.0.2.tgz",
+      "integrity": "sha512-1MLa5ouZiOmQzUbjbu9VmjLzn1QLXBhwpUa7kdLUQK+KQ5KA9I1vk5U4YHe/X2Ch7PYnJfWuWT+VbuxbGwljhw==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "base64-arraybuffer": "^1.0.2"
       }
     },
     "node_modules/v8-to-istanbul": {

--- a/package.json
+++ b/package.json
@@ -12,5 +12,8 @@
   "type": "commonjs",
   "devDependencies": {
     "jest": "^30.1.1"
+  },
+  "dependencies": {
+    "jspdf": "^2.5.1"
   }
 }

--- a/pdf.js
+++ b/pdf.js
@@ -1,0 +1,72 @@
+let jsPDFLib;
+if (typeof window !== 'undefined' && window.jspdf) {
+  jsPDFLib = window.jspdf.jsPDF;
+} else {
+  jsPDFLib = require('jspdf').jsPDF;
+}
+
+function generatePdf(data) {
+  const doc = new jsPDFLib();
+  const margin = 10;
+  let y = margin;
+  const now = new Date().toLocaleString();
+
+  doc.setFontSize(16);
+  doc.text('Salary Calculation', margin, y);
+  y += 8;
+  doc.setFontSize(10);
+  doc.text(`Generated: ${now}`, margin, y);
+  y += 10;
+
+  doc.setFontSize(12);
+  doc.text('Input Parameters', margin, y);
+  y += 6;
+  doc.setFontSize(10);
+  const inputs = [
+    `Date: ${data.date || ''}`,
+    `Shift: ${data.shift}`,
+    `Zone: ${data.zone_label || data.zone}`,
+    `Capacity: ${data.capacity}`,
+    `N: ${data.N}`,
+    `ESI: ${data.ESI.n1}/${data.ESI.n2}/${data.ESI.n3}/${data.ESI.n4}/${data.ESI.n5}`
+  ];
+  inputs.forEach(line => { doc.text(line, margin, y); y += 5; });
+
+  y += 5;
+  doc.setFontSize(12);
+  doc.text('Bonuses', margin, y);
+  y += 6;
+  doc.setFontSize(10);
+  const bonuses = [
+    `V_bonus: ${data.V_bonus.toFixed(2)}`,
+    `A_bonus: ${data.A_bonus.toFixed(2)}`,
+    `K_zona: ${data.K_zona.toFixed(2)}`
+  ];
+  bonuses.forEach(line => { doc.text(line, margin, y); y += 5; });
+
+  y += 5;
+  doc.setFontSize(12);
+  doc.text('Rates', margin, y);
+  y += 6;
+  doc.setFontSize(10);
+  ['doctor','nurse','assistant'].forEach(role => {
+    doc.text(
+      `${role}: base ${data.base_rates[role].toFixed(2)} final ${data.final_rates[role].toFixed(2)} shift ${data.shift_salary[role].toFixed(2)} month ${data.month_salary[role].toFixed(2)}`,
+      margin,
+      y
+    );
+    y += 5;
+  });
+
+  return doc;
+}
+
+const exported = { generatePdf };
+
+if (typeof module !== 'undefined') {
+  module.exports = exported;
+}
+
+if (typeof window !== 'undefined') {
+  window.pdfUtils = exported;
+}

--- a/tests/pdf.test.js
+++ b/tests/pdf.test.js
@@ -1,0 +1,32 @@
+const { compute } = require('../compute.js');
+const { generatePdf } = require('../pdf.js');
+
+describe('PDF generation', () => {
+  test('runs without errors', () => {
+    const data = compute({
+      C: 10,
+      kMax: 1.3,
+      baseDoc: 20,
+      baseNurse: 10,
+      baseAssist: 5,
+      shiftH: 12,
+      monthH: 160,
+      n1: 1,
+      n2: 2,
+      n3: 3,
+      n4: 4,
+      n5: 5,
+      N: undefined,
+    });
+    const doc = generatePdf({
+      date: '2024-01-01',
+      shift: 'D',
+      zone: 'Z',
+      zone_label: 'Zone Z',
+      capacity: 10,
+      ...data,
+    });
+    expect(doc).toBeDefined();
+    expect(typeof doc.save).toBe('function');
+  });
+});


### PR DESCRIPTION
## Summary
- add a "Download PDF" action beside existing exports and load the jsPDF library
- implement PDF generation utility collecting inputs, bonuses, rates and timestamp
- test PDF generation with mock data to ensure it executes without errors

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b5e44ca9b08320881db360dd294e3b