### PR TITLE
Gracefully handle missing jsPDF for PDF downloads

### DIFF
--- a/app.js
+++ b/app.js
@@ -437,9 +437,14 @@ function downloadCsv(){
 }
 
 function downloadPdf(){
-  const data = compute();
-  const doc = pdfUtils.generatePdf(data);
-  doc.save('salary_calc.pdf');
+  try {
+    const data = compute();
+    const doc = pdfUtils.generatePdf(data);
+    doc.save('salary_calc.pdf');
+  } catch (err) {
+    alert('Nepavyko sugeneruoti PDF. Patikrinkite ar įkelta jsPDF biblioteka.');
+    console.error(err);
+  }
 }
 
 // --- Įvykiai ---

--- a/pdf.js
+++ b/pdf.js
@@ -1,11 +1,21 @@
 let jsPDFLib;
-if (typeof window !== 'undefined' && window.jspdf) {
-  jsPDFLib = window.jspdf.jsPDF;
-} else {
-  jsPDFLib = require('jspdf').jsPDF;
+if (typeof window !== 'undefined') {
+  // jsPDF v2 UMD exposes window.jspdf.jsPDF, but some builds expose window.jsPDF.
+  jsPDFLib = window.jspdf?.jsPDF || window.jsPDF;
+}
+if (!jsPDFLib) {
+  try {
+    const jspdf = require('jspdf');
+    jsPDFLib = jspdf.jsPDF || jspdf.default;
+  } catch (err) {
+    console.error('jsPDF library not found', err);
+  }
 }
 
 function generatePdf(data) {
+  if (!jsPDFLib) {
+    throw new Error('jsPDF library is not loaded');
+  }
   const doc = new jsPDFLib();
   const margin = 10;
   let y = margin;


### PR DESCRIPTION
## Summary
- Improve jsPDF detection in browser/Node to avoid crashes if library isn't loaded
- Alert user when PDF generation fails instead of silently doing nothing

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b5e5ad4d888320957899e7d1c71ca5