### PR TITLE
Add configurable bonus thresholds

### DIFF
--- a/app.js
+++ b/app.js
@@ -30,6 +30,7 @@ if (toggle) {
 
     const LS_KEY = 'ED_ZONES_V2';
     const LS_RATE_KEY = 'ED_RATE_TEMPLATE_V2';
+    const LS_THRESH_KEY = 'ED_THRESHOLDS';
 
     function clone(obj){ return JSON.parse(JSON.stringify(obj)); }
     function sanitizeId(txt){ const s = (txt||'').toString().toUpperCase().replace(/[^A-Z0-9]+/g,'_').replace(/^_|_$/g,''); return s || 'ZONE_' + Math.random().toString(36).slice(2,6).toUpperCase(); }
@@ -112,7 +113,9 @@ if (toggle) {
       defaultsZones: document.getElementById('defaultsZones'),
       closeZoneModal: document.getElementById('closeZoneModal'),
       saveRateTemplate: document.getElementById('saveRateTemplate'),
-      loadRateTemplate: document.getElementById('loadRateTemplate')
+      loadRateTemplate: document.getElementById('loadRateTemplate'),
+      saveThresholds: document.getElementById('saveThresholds'),
+      resetThresholds: document.getElementById('resetThresholds')
     };
 
     const style = getComputedStyle(document.documentElement);
@@ -447,6 +450,56 @@ function downloadPdf(){
   }
 }
 
+function loadThresholdInputs(){
+  const tables = computeCore.loadThresholds();
+  tables.V_BONUS.forEach((row, i) => {
+    const l = document.getElementById(`vLimit${i}`);
+    const v = document.getElementById(`vValue${i}`);
+    if (l) l.value = row.limit === Infinity ? '' : row.limit;
+    if (v) v.value = row.value;
+  });
+  tables.A_BONUS.forEach((row, i) => {
+    const l = document.getElementById(`aLimit${i}`);
+    const v = document.getElementById(`aValue${i}`);
+    if (l) l.value = row.limit === Infinity ? '' : row.limit;
+    if (v) v.value = row.value;
+  });
+}
+
+function readThresholdInputs(){
+  const v = [], a = [];
+  for(let i=0;i<4;i++){
+    const l = document.getElementById(`vLimit${i}`);
+    const val = document.getElementById(`vValue${i}`);
+    const limit = parseFloat(l?.value);
+    const value = parseFloat(val?.value);
+    v.push({ limit: Number.isFinite(limit) ? limit : Infinity, value: Number.isFinite(value) ? value : 0 });
+    const la = document.getElementById(`aLimit${i}`);
+    const va = document.getElementById(`aValue${i}`);
+    const limitA = parseFloat(la?.value);
+    const valueA = parseFloat(va?.value);
+    a.push({ limit: Number.isFinite(limitA) ? limitA : Infinity, value: Number.isFinite(valueA) ? valueA : 0 });
+  }
+  return { V_BONUS: v, A_BONUS: a };
+}
+
+function saveThresholdSettings(){
+  try {
+    const data = readThresholdInputs();
+    localStorage.setItem(LS_THRESH_KEY, JSON.stringify(data));
+    compute();
+  } catch (err) {
+    console.error('Failed to save thresholds', err);
+    alert('Nepavyko išsaugoti slenksčių.');
+  }
+}
+
+function resetThresholdSettings(){
+  try { localStorage.removeItem(LS_THRESH_KEY); } catch {}
+  loadThresholdInputs();
+  compute();
+}
+
 // --- Įvykiai ---
 ['input','change'].forEach(evt => {
   ['date','zone','capacity','N','kmax','shiftHours','monthHours','baseRateDoc','baseRateNurse','baseRateAssist','linkN','esi1','esi2','esi3','esi4','esi5'].forEach(id => {
@@ -478,11 +531,15 @@ els.zone.addEventListener('change', setDefaultCapacity);
     els.defaultsZones.addEventListener('click', resetToDefaults);
     els.closeZoneModal.addEventListener('click', closeZoneModal);
 
+    els.saveThresholds.addEventListener('click', (e)=>{ e.preventDefault(); saveThresholdSettings(); });
+    els.resetThresholds.addEventListener('click', (e)=>{ e.preventDefault(); resetThresholdSettings(); });
+
     // Tarifų šablonai
     els.saveRateTemplate.addEventListener('click', (e)=>{ e.preventDefault(); saveRateTemplate(); });
     els.loadRateTemplate.addEventListener('click', (e)=>{ e.preventDefault(); loadRateTemplate(); });
 
     // Init
     renderZoneSelect(false);
+    loadThresholdInputs();
     resetAll();
 

--- a/compute.js
+++ b/compute.js
@@ -1,4 +1,4 @@
-const THRESHOLDS = {
+const DEFAULT_THRESHOLDS = {
   V_BONUS: [
     { limit: 0.80, value: 0.00 },
     { limit: 1.00, value: 0.05 },
@@ -12,6 +12,30 @@ const THRESHOLDS = {
     { limit: Infinity, value: 0.15 },
   ],
 };
+
+const THRESHOLD_LS_KEY = 'ED_THRESHOLDS';
+
+function loadThresholds() {
+  if (typeof localStorage !== 'undefined') {
+    try {
+      const raw = localStorage.getItem(THRESHOLD_LS_KEY);
+      if (raw) {
+        const parsed = JSON.parse(raw);
+        if (
+          parsed &&
+          typeof parsed === 'object' &&
+          Array.isArray(parsed.V_BONUS) &&
+          Array.isArray(parsed.A_BONUS)
+        ) {
+          return parsed;
+        }
+      }
+    } catch (err) {
+      // ignore parse/storage errors and fall back to defaults
+    }
+  }
+  return DEFAULT_THRESHOLDS;
+}
 
 function getBonus(metric, table) {
   for (const { limit, value } of table) {
@@ -52,10 +76,11 @@ function compute({
     ? Math.max(0, N)
     : sN1 + sN2 + sN3 + sN4 + sN5;
   const ratio = c > 0 ? totalN / c : 0;
-  const V = getBonus(ratio, THRESHOLDS.V_BONUS);
+  const thresholds = loadThresholds();
+  const V = getBonus(ratio, thresholds.V_BONUS);
   const high = sN1 + sN2;
   const S = totalN > 0 ? high / totalN : 0;
-  const A = getBonus(S, THRESHOLDS.A_BONUS);
+  const A = getBonus(S, thresholds.A_BONUS);
   const K = Math.max(0, Math.min(1 + V + A, k));
 
   const finalDoc = Math.max(0, baseDoc * K);
@@ -104,7 +129,12 @@ function compute({
   };
 }
 
-const exported = { THRESHOLDS, getBonus, compute };
+const exported = {
+  THRESHOLDS: DEFAULT_THRESHOLDS,
+  getBonus,
+  compute,
+  loadThresholds,
+};
 
 if (typeof module !== 'undefined') {
   module.exports = exported;

--- a/index.html
+++ b/index.html
@@ -208,6 +208,38 @@
         </div>
       </div>
     </div>
+    <div class="card">
+      <h2>Nustatymai</h2>
+      <h3>V priedo slenksčiai</h3>
+      <table class="table">
+        <thead>
+          <tr><th>Riba N/C</th><th>Priedas</th></tr>
+        </thead>
+        <tbody>
+          <tr><td><input id="vLimit0" type="number" step="0.01" /></td><td><input id="vValue0" type="number" step="0.01" /></td></tr>
+          <tr><td><input id="vLimit1" type="number" step="0.01" /></td><td><input id="vValue1" type="number" step="0.01" /></td></tr>
+          <tr><td><input id="vLimit2" type="number" step="0.01" /></td><td><input id="vValue2" type="number" step="0.01" /></td></tr>
+          <tr><td><input id="vLimit3" type="number" step="0.01" /></td><td><input id="vValue3" type="number" step="0.01" /></td></tr>
+        </tbody>
+      </table>
+      <h3>A priedo slenksčiai</h3>
+      <table class="table">
+        <thead>
+          <tr><th>Riba S</th><th>Priedas</th></tr>
+        </thead>
+        <tbody>
+          <tr><td><input id="aLimit0" type="number" step="0.01" /></td><td><input id="aValue0" type="number" step="0.01" /></td></tr>
+          <tr><td><input id="aLimit1" type="number" step="0.01" /></td><td><input id="aValue1" type="number" step="0.01" /></td></tr>
+          <tr><td><input id="aLimit2" type="number" step="0.01" /></td><td><input id="aValue2" type="number" step="0.01" /></td></tr>
+          <tr><td><input id="aLimit3" type="number" step="0.01" /></td><td><input id="aValue3" type="number" step="0.01" /></td></tr>
+        </tbody>
+      </table>
+      <div class="actions">
+        <button id="saveThresholds">Išsaugoti slenksčius</button>
+        <button id="resetThresholds">Numatytieji</button>
+      </div>
+      <div class="help">Slenksčiai saugomi vietoje (localStorage).</div>
+    </div>
   </div>
 
   <!-- ZONŲ TVARKYMO MODALAS (drag&drop + grupės) -->

--- a/tests/compute.test.js
+++ b/tests/compute.test.js
@@ -1,6 +1,7 @@
 const { compute } = require('../compute');
 
 describe('compute core logic', () => {
+  afterEach(() => { delete global.localStorage; });
   test('low occupancy yields no V bonus', () => {
     const result = compute({
       C: 100,
@@ -128,5 +129,44 @@ describe('compute core logic', () => {
     expect(result.K_zona).toBe(0);
     expect(result.shift_salary.doctor).toBe(0);
     expect(result.month_salary.doctor).toBe(0);
+  });
+
+  test('uses thresholds from localStorage', () => {
+    const custom = {
+      V_BONUS: [
+        { limit: 1, value: 0 },
+        { limit: 2, value: 0.5 },
+        { limit: 3, value: 0.75 },
+        { limit: Infinity, value: 1 },
+      ],
+      A_BONUS: [
+        { limit: 0.1, value: 0 },
+        { limit: 0.5, value: 0.2 },
+        { limit: 0.9, value: 0.3 },
+        { limit: Infinity, value: 0.4 },
+      ],
+    };
+    global.localStorage = {
+      getItem: () => JSON.stringify(custom),
+      setItem: () => {},
+    };
+    const result = compute({
+      C: 100,
+      N: 150,
+      kMax: 2,
+      baseDoc: 10,
+      baseNurse: 10,
+      baseAssist: 10,
+      shiftH: 0,
+      monthH: 0,
+      n1: 20,
+      n2: 5,
+      n3: 125,
+      n4: 0,
+      n5: 0,
+    });
+    expect(result.V_bonus).toBe(0.5);
+    expect(result.A_bonus).toBe(0.2);
+    expect(result.K_zona).toBeCloseTo(1.7);
   });
 });


### PR DESCRIPTION
## Summary
- Load bonus threshold tables from `localStorage` when available before falling back to defaults
- Add settings UI to edit V and A threshold limit/value pairs with persistence
- Provide app logic to read, validate, and save custom thresholds
- Extend compute tests to cover custom threshold scenario

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b5ebebfcbc83208ede54841f7d15ee