### PR TITLE
fix: improve jsPDF detection

### DIFF
--- a/pdf.js
+++ b/pdf.js
@@ -1,12 +1,16 @@
 let jsPDFLib;
 if (typeof window !== 'undefined') {
   // jsPDF v2 UMD exposes window.jspdf.jsPDF, but some builds expose window.jsPDF.
-  jsPDFLib = window.jspdf?.jsPDF || window.jsPDF;
+  if (window.jspdf && window.jspdf.jsPDF) {
+    jsPDFLib = window.jspdf.jsPDF;
+  } else if (window.jsPDF) {
+    jsPDFLib = window.jsPDF;
+  }
 }
 if (!jsPDFLib) {
   try {
     const jspdf = require('jspdf');
-    jsPDFLib = jspdf.jsPDF || jspdf.default;
+    jsPDFLib = jspdf.jsPDF || (jspdf.default && jspdf.default.jsPDF) || jspdf.default || jspdf;
   } catch (err) {
     console.error('jsPDF library not found', err);
   }


### PR DESCRIPTION
## Summary
- handle more jsPDF loading scenarios to avoid PDF generation failures across environments

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b68da216588320bf7ecd4aa93a9075