### PR TITLE
Clarify patient and capacity terminology

### DIFF
--- a/compute.js
+++ b/compute.js
@@ -25,8 +25,8 @@ function sanitize(value) {
 }
 
 function compute({
-  C,
-  kMax,
+  zoneCapacity,
+  maxCoefficient,
   baseDoc,
   baseNurse,
   baseAssist,
@@ -37,10 +37,14 @@ function compute({
   n3,
   n4,
   n5,
+  patientCount,
+  // Legacy support
+  C,
+  kMax,
   N,
 }) {
-  const c = sanitize(C);
-  const k = sanitize(kMax);
+  const c = sanitize(zoneCapacity ?? C);
+  const k = sanitize(maxCoefficient ?? kMax);
   const sh = sanitize(shiftH);
   const mh = sanitize(monthH);
   const sN1 = sanitize(n1);
@@ -48,8 +52,8 @@ function compute({
   const sN3 = sanitize(n3);
   const sN4 = sanitize(n4);
   const sN5 = sanitize(n5);
-  const totalN = Number.isFinite(N)
-    ? Math.max(0, N)
+  const totalN = Number.isFinite(patientCount ?? N)
+    ? Math.max(0, patientCount ?? N)
     : sN1 + sN2 + sN3 + sN4 + sN5;
   const ratio = c > 0 ? totalN / c : 0;
   const V = getBonus(ratio, THRESHOLDS.V_BONUS);
@@ -71,12 +75,14 @@ function compute({
   const monthAssist = finalAssist * mh;
 
   return {
+    patientCount: totalN,
     N: totalN,
     ESI: { n1: sN1, n2: sN2, n3: sN3, n4: sN4, n5: sN5 },
     ratio,
     S,
     V_bonus: V,
     A_bonus: A,
+    maxCoefficient: k,
     K_max: k,
     K_zona: K,
     shift_hours: sh,

--- a/index.html
+++ b/index.html
@@ -44,20 +44,23 @@
             </div>
           </div>
           <div>
-            <label for="capacity">Talpa C (pac./pam.)</label>
-            <input id="capacity" type="number" min="0" step="1" placeholder="pvz. 16" />
+            <label for="zoneCapacity">Zonos talpa (pac./pam.)</label>
+            <input id="zoneCapacity" type="number" min="0" step="1" placeholder="pvz. 16" />
             <div class="help">Keičiant zoną/pamainą įstatoma numatytoji talpa (galite perrašyti).</div>
+            <!-- formerly id="capacity" representing C -->
           </div>
         </div>
 
         <div class="row">
           <div>
-            <label for="N">Pacientų N (zonoje per pamainą)</label>
-            <input id="N" type="number" min="0" step="1" value="0" />
+            <label for="patientCount">Pacientų skaičius (zonoje per pamainą)</label>
+            <input id="patientCount" type="number" min="0" step="1" value="0" />
+            <!-- formerly id="N" -->
           </div>
           <div>
-            <label for="kmax">K<sub>max</sub> (lubos)</label>
-            <input id="kmax" type="number" min="1" max="2" step="0.01" value="1.30" />
+            <label for="maxCoefficient">Maksimalus koeficientas</label>
+            <input id="maxCoefficient" type="number" min="1" max="2" step="0.01" value="1.30" />
+            <!-- formerly id="kmax" -->
           </div>
         </div>
 
@@ -99,8 +102,9 @@
 
         <div class="switch-block">
           <label class="switch">
-            <input id="linkN" type="checkbox" checked />
-            <span>Naudoti N = ESI1+ESI2+ESI3+ESI4+ESI5</span>
+            <input id="linkPatientCount" type="checkbox" checked />
+            <span>Naudoti Pacientų skaičių = ESI1+ESI2+ESI3+ESI4+ESI5</span>
+            <!-- formerly id="linkN" -->
           </label>
         </div>
 
@@ -146,13 +150,13 @@
         <h2>Rezultatai</h2>
         <div class="kpi">
           <div class="item">
-            <div class="label">Santykis N/C</div>
+            <div class="label">Santykis Pacientų skaičius/Zonos talpa</div>
             <div class="val" id="ratio">0.00</div>
             <canvas id="ratioChart"></canvas>
             <div class="help">Apkrovos intervalas lemia V<sub>priedas</sub></div>
           </div>
           <div class="item">
-            <div class="label">Aukštos skubos dalis S = (ESI1+ESI2)/N</div>
+            <div class="label">Aukštos skubos dalis S = (ESI1+ESI2)/Pacientų skaičius</div>
             <div class="val" id="sShare">0.00</div>
             <canvas id="sChart"></canvas>
             <div class="help">Lemia A<sub>priedas</sub></div>
@@ -179,14 +183,14 @@
               </td>
             </tr>
             <tr>
-              <td>K<sub>max</sub> (lubos)</td>
-              <td id="kMaxCell">1.30</td>
+              <td>Maksimalus koeficientas</td>
+              <td id="maxCoefficientCell">1.30</td>
               <td>Galinio koeficiento riba</td>
             </tr>
             <tr>
               <td class="accent">K<sub>zona</sub></td>
               <td class="accent" id="kZona">1.00</td>
-              <td>min(1 + V + A, K<sub>max</sub>)</td>
+              <td>min(1 + V + A, Maksimalus koeficientas)</td>
             </tr>
           </tbody>
         </table>
@@ -204,7 +208,7 @@
         </table>
 
         <div class="footer">
-          Patarimas: jei dažnai pasiekiate lubas, padidinkite talpą C arba sumažinkite priedų laiptelius.
+          Patarimas: jei dažnai pasiekiate lubas, padidinkite zonos talpą arba sumažinkite priedų laiptelius.
         </div>
       </div>
     </div>

--- a/pdf.js
+++ b/pdf.js
@@ -40,8 +40,8 @@ function generatePdf(data) {
     `Date: ${data.date || ''}`,
     `Shift: ${data.shift}`,
     `Zone: ${data.zone_label || data.zone}`,
-    `Capacity: ${data.capacity}`,
-    `N: ${data.N}`,
+    `Zonos talpa: ${data.zoneCapacity}`,
+    `Pacientų skaičius: ${data.patientCount}`,
     `ESI: ${data.ESI.n1}/${data.ESI.n2}/${data.ESI.n3}/${data.ESI.n4}/${data.ESI.n5}`
   ];
   inputs.forEach(line => { doc.text(line, margin, y); y += 5; });

--- a/tests/compute.test.js
+++ b/tests/compute.test.js
@@ -3,9 +3,9 @@ const { compute } = require('../compute');
 describe('compute core logic', () => {
   test('low occupancy yields no V bonus', () => {
     const result = compute({
-      C: 100,
-      N: 50,
-      kMax: 1.3,
+      zoneCapacity: 100,
+      patientCount: 50,
+      maxCoefficient: 1.3,
       baseDoc: 10,
       baseNurse: 10,
       baseAssist: 10,
@@ -24,9 +24,9 @@ describe('compute core logic', () => {
 
   test('medium occupancy and acuity bonuses combine', () => {
     const result = compute({
-      C: 80,
-      N: 100,
-      kMax: 1.3,
+      zoneCapacity: 80,
+      patientCount: 100,
+      maxCoefficient: 1.3,
       baseDoc: 10,
       baseNurse: 10,
       baseAssist: 10,
@@ -45,9 +45,9 @@ describe('compute core logic', () => {
 
   test('bonuses capped by kMax', () => {
     const result = compute({
-      C: 80,
-      N: 120,
-      kMax: 1.3,
+      zoneCapacity: 80,
+      patientCount: 120,
+      maxCoefficient: 1.3,
       baseDoc: 10,
       baseNurse: 10,
       baseAssist: 10,
@@ -66,9 +66,9 @@ describe('compute core logic', () => {
 
   test('handles NaN inputs with safe defaults', () => {
     const result = compute({
-      C: NaN,
-      N: NaN,
-      kMax: NaN,
+      zoneCapacity: NaN,
+      patientCount: NaN,
+      maxCoefficient: NaN,
       baseDoc: 10,
       baseNurse: 10,
       baseAssist: 10,
@@ -80,7 +80,7 @@ describe('compute core logic', () => {
       n4: NaN,
       n5: NaN,
     });
-    expect(result.N).toBe(0);
+    expect(result.patientCount).toBe(0);
     expect(result.K_zona).toBe(0);
     expect(result.shift_salary.doctor).toBe(0);
     expect(result.month_salary.doctor).toBe(0);
@@ -88,9 +88,9 @@ describe('compute core logic', () => {
 
   test('clamps negative values to zero', () => {
     const result = compute({
-      C: -100,
-      N: -50,
-      kMax: -1,
+      zoneCapacity: -100,
+      patientCount: -50,
+      maxCoefficient: -1,
       baseDoc: 10,
       baseNurse: 10,
       baseAssist: 10,
@@ -102,7 +102,7 @@ describe('compute core logic', () => {
       n4: -5,
       n5: -5,
     });
-    expect(result.N).toBe(0);
+    expect(result.patientCount).toBe(0);
     expect(result.ratio).toBe(0);
     expect(result.shift_hours).toBe(0);
     expect(result.month_hours).toBe(0);
@@ -110,9 +110,9 @@ describe('compute core logic', () => {
 
   test('ignores infinite values', () => {
     const result = compute({
-      C: Infinity,
-      N: Infinity,
-      kMax: Infinity,
+      zoneCapacity: Infinity,
+      patientCount: Infinity,
+      maxCoefficient: Infinity,
       baseDoc: 10,
       baseNurse: 10,
       baseAssist: 10,
@@ -124,7 +124,7 @@ describe('compute core logic', () => {
       n4: Infinity,
       n5: Infinity,
     });
-    expect(result.N).toBe(0);
+    expect(result.patientCount).toBe(0);
     expect(result.K_zona).toBe(0);
     expect(result.shift_salary.doctor).toBe(0);
     expect(result.month_salary.doctor).toBe(0);

--- a/tests/csv.test.js
+++ b/tests/csv.test.js
@@ -38,14 +38,14 @@ test('handles commas in zone_label', () => {
     shift: 'D',
     zone: 'RED',
     zone_label: 'Critical, Red Zone',
-    capacity: 20,
-    N: 10,
+    zoneCapacity: 20,
+    patientCount: 10,
     ESI: { n1: 1, n2: 2, n3: 3, n4: 4, n5: 0 },
     ratio: 0.5,
     S: 0.3,
     V_bonus: 0.1,
     A_bonus: 0.05,
-    K_max: 1.3,
+    maxCoefficient: 1.3,
     K_zona: 1.15,
     shift_hours: 8,
     month_hours: 160,
@@ -60,8 +60,8 @@ test('handles commas in zone_label', () => {
     ['shift', data.shift],
     ['zone', data.zone],
     ['zone_label', data.zone_label],
-    ['capacity', data.capacity],
-    ['N', data.N],
+    ['zoneCapacity', data.zoneCapacity],
+    ['patientCount', data.patientCount],
     ['ESI1', data.ESI.n1],
     ['ESI2', data.ESI.n2],
     ['ESI3', data.ESI.n3],
@@ -71,7 +71,7 @@ test('handles commas in zone_label', () => {
     ['S', data.S],
     ['V_bonus', data.V_bonus],
     ['A_bonus', data.A_bonus],
-    ['K_max', data.K_max],
+    ['maxCoefficient', data.maxCoefficient],
     ['K_zona', data.K_zona],
     ['shift_hours', data.shift_hours],
     ['month_hours', data.month_hours],
@@ -98,7 +98,7 @@ test('handles commas in zone_label', () => {
 test('csv remains valid when zone_label has commas and quotes', () => {
   const rows = [
     ['zone_label', 'Critical, "Red" Zone'],
-    ['capacity', 20],
+    ['zoneCapacity', 20],
   ];
   const csv = rowsToCsv(rows);
   const values = parseCsvLine(csv.split('\n')[1]);

--- a/tests/pdf.test.js
+++ b/tests/pdf.test.js
@@ -4,8 +4,8 @@ const { generatePdf } = require('../pdf.js');
 describe('PDF generation', () => {
   test('runs without errors', () => {
     const data = compute({
-      C: 10,
-      kMax: 1.3,
+      zoneCapacity: 10,
+      maxCoefficient: 1.3,
       baseDoc: 20,
       baseNurse: 10,
       baseAssist: 5,
@@ -16,14 +16,14 @@ describe('PDF generation', () => {
       n3: 3,
       n4: 4,
       n5: 5,
-      N: undefined,
+      patientCount: undefined,
     });
     const doc = generatePdf({
       date: '2024-01-01',
       shift: 'D',
       zone: 'Z',
       zone_label: 'Zone Z',
-      capacity: 10,
+      zoneCapacity: 10,
       ...data,
     });
     expect(doc).toBeDefined();


### PR DESCRIPTION
## Summary
- Replace ambiguous N/C/kmax labels with Pacientų skaičius, Zonos talpa and Maksimalus koeficientas
- Update core compute logic and exports to use new parameter names while keeping legacy aliases
- Refresh tests and PDF/CSV exports for the renamed fields

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b6caa74990832095675d6780bc2e52