### PR TITLE
Add Playwright tests and CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,20 @@
+name: CI
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: 'npm'
+      - run: npm ci
+      - run: npx playwright install --with-deps
+      - run: npm test
+      - run: npm run test:e2e

--- a/e2e/app.spec.js
+++ b/e2e/app.spec.js
@@ -1,0 +1,61 @@
+const { test, expect } = require('@playwright/test');
+const path = require('path');
+
+const fileUrl = 'file://' + path.resolve(__dirname, '../index.html');
+
+test.beforeEach(async ({ page }) => {
+  await page.addInitScript(() => {
+    window.Chart = class {
+      constructor() {
+        return { data: { datasets: [{ data: [] }] }, update() {}, destroy() {} };
+      }
+    };
+    window.jspdf = {
+      jsPDF: class {
+        constructor() {}
+        setFontSize() {}
+        text() {}
+        save(name) { window.__pdfSaved = name; }
+      }
+    };
+  });
+  await page.goto(fileUrl);
+});
+
+test('updates final salary based on user input', async ({ page }) => {
+  await page.fill('#zoneCapacity', '10');
+  await page.fill('#patientCount', '20');
+  await page.fill('#esi1', '3');
+  await page.fill('#esi2', '2');
+  await page.fill('#baseRateDoc', '10');
+  const kZona = await page.textContent('#kZona');
+  expect(kZona.trim()).toBe('1.25');
+  const finalDocText = await page.textContent('#finalDocCell');
+  const finalDoc = parseFloat(finalDocText.replace(/[^0-9,-]/g, '').replace(',', '.'));
+  expect(finalDoc).toBeCloseTo(12.5, 1);
+});
+
+test('adds new zone through zone management modal', async ({ page }) => {
+  await page.click('#manageZones');
+  await page.click('#addZone');
+  await page.click('#saveZonesBtn');
+  await page.selectOption('#zone', { label: 'Nauja zona' });
+  const selectedLabel = await page.$eval('#zone', el => el.options[el.selectedIndex].textContent);
+  expect(selectedLabel).toBe('Nauja zona');
+});
+
+test('triggers CSV and PDF exports', async ({ page }) => {
+  await page.fill('#zoneCapacity', '10');
+  await page.fill('#patientCount', '20');
+  await page.fill('#esi1', '3');
+  await page.fill('#esi2', '2');
+  await page.fill('#baseRateDoc', '10');
+  const [download] = await Promise.all([
+    page.waitForEvent('download'),
+    page.click('#downloadCsv'),
+  ]);
+  expect(download.suggestedFilename()).toBe('salary_calc.csv');
+  await page.click('#downloadPdf');
+  const pdfSaved = await page.evaluate(() => window.__pdfSaved);
+  expect(pdfSaved).toBe('salary_calc.pdf');
+});

--- a/jest.config.js
+++ b/jest.config.js
@@ -1,3 +1,4 @@
 module.exports = {
   testEnvironment: 'jsdom',
+  testPathIgnorePatterns: ['<rootDir>/e2e/'],
 };

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,6 +13,7 @@
       },
       "devDependencies": {
         "@babel/preset-env": "^7.28.3",
+        "@playwright/test": "^1.55.0",
         "jest": "^30.1.1",
         "jest-environment-jsdom": "^30.1.2"
       }
@@ -2477,6 +2478,22 @@
       },
       "funding": {
         "url": "https://opencollective.com/pkgr"
+      }
+    },
+    "node_modules/@playwright/test": {
+      "version": "1.55.0",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.55.0.tgz",
+      "integrity": "sha512-04IXzPwHrW69XusN/SIdDdKZBzMfOT9UNT/YiJit/xpy2VuAoB8NHc8Aplb96zsWDddLnbkPL3TsmrS04ZU2xQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright": "1.55.0"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/@sinclair/typebox": {
@@ -5535,6 +5552,53 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/playwright": {
+      "version": "1.55.0",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.55.0.tgz",
+      "integrity": "sha512-sdCWStblvV1YU909Xqx0DhOjPZE4/5lJsIS84IfN9dAZfcl/CIZ5O8l3o0j7hPMjDvqoTF8ZUcc+i/GL5erstA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright-core": "1.55.0"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.55.0",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.55.0.tgz",
+      "integrity": "sha512-GvZs4vU3U5ro2nZpeiwyb0zuFaqb9sUiAJuyrWpcGouD8y9/HLgGbNRjIph7zU9D3hnPaisMl9zG9CgFi/biIg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/playwright/node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
     },
     "node_modules/pretty-format": {

--- a/package.json
+++ b/package.json
@@ -4,7 +4,8 @@
   "description": "This project is a web-based tool for calculating salary rates in an emergency department. It computes a zone coefficient based on patient load and triage levels, then applies it to base hourly wages for doctors, nurses and assistants to produce final pay rates.",
   "main": "ui.js",
   "scripts": {
-    "test": "jest"
+    "test": "jest",
+    "test:e2e": "playwright test"
   },
   "keywords": [],
   "author": "",
@@ -12,6 +13,7 @@
   "type": "commonjs",
   "devDependencies": {
     "@babel/preset-env": "^7.28.3",
+    "@playwright/test": "^1.55.0",
     "jest": "^30.1.1",
     "jest-environment-jsdom": "^30.1.2"
   },

--- a/playwright.config.js
+++ b/playwright.config.js
@@ -1,0 +1,5 @@
+const { defineConfig } = require('@playwright/test');
+
+module.exports = defineConfig({
+  testDir: './e2e'
+});


### PR DESCRIPTION
## Summary
- add Playwright-powered end-to-end tests for user flows and exports
- configure Jest to ignore e2e tests and add Playwright config
- run unit and browser tests in CI

## Testing
- `npm test`
- `npx playwright test` *(fails: browserType.launch: Executable doesn't exist at /root/.cache/ms-playwright/chromium_headless_shell-1187/chrome-linux/headless_shell)*

------
https://chatgpt.com/codex/tasks/task_e_68b70b4de260832083c5e7a591a58ff2