### PR TITLE
Add focus-visible styling for switches

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -61,6 +61,7 @@
     .help { font-size: 12px; color: var(--muted); margin-top: 6px; }
     .switch { display: inline-flex; align-items: center; gap: 8px; user-select: none; cursor: pointer; font-size: 13px; color: var(--muted); }
     .switch input { appearance: none; width: 38px; height: 22px; background: var(--border); border-radius: 999px; position: relative; outline: none; transition: background .2s; }
+    .switch input:focus-visible { outline: none; box-shadow: 0 0 0 2px var(--accent-2); }
     .switch input::after { content:""; position: absolute; top: 3px; left: 3px; width: 16px; height: 16px; background: #fff; border-radius: 50%; transition: transform .2s; }
     .switch input:checked { background: #1f7af8; }
     .switch input:checked::after { transform: translateX(16px); }


### PR DESCRIPTION
## Summary
- emphasize focus states for toggle switches using an accent-colored box-shadow
- ensures visible focus indication across light and dark themes

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b74553566083208b93bade6ee59dd9