### PR TITLE
Add modal accessibility attributes and fade transition

### DIFF
--- a/index.html
+++ b/index.html
@@ -215,7 +215,7 @@
   </div>
 
   <!-- ZONŲ TVARKYMO MODALAS (drag&drop + grupės) -->
-  <div class="modal" id="zoneModal" aria-hidden="true">
+  <div class="modal" id="zoneModal" aria-hidden="true" role="dialog" aria-modal="true">
     <div class="dialog">
       <h3>Zonų tvarkymas</h3>
       <div class="help">Pridėkite, redaguokite, <strong>rikiuokite (drag&drop)</strong> ir grupuokite zonas. Pakeitimai saugomi šiame įrenginyje (<em>localStorage</em>).</div>

--- a/styles.css
+++ b/styles.css
@@ -98,8 +98,8 @@
     .footer { margin-top: 18px; font-size: var(--font-xs); color: var(--muted); }
 
     /* Modal */
-    .modal { position: fixed; inset: 0; background: rgba(3,6,23,0.65); display: none; align-items: center; justify-content: center; padding: 16px; z-index: 50; }
-    .modal.active { display: flex; }
+    .modal { position: fixed; inset: 0; background: rgba(3,6,23,0.65); display: none; align-items: center; justify-content: center; padding: 16px; z-index: 50; opacity: 0; transition: opacity .3s ease; }
+    .modal.active { display: flex; opacity: 1; }
     .dialog { width: min(980px, 96vw); background: radial-gradient(1000px 400px at 10% 0%, var(--panel), var(--card)); border: 1px solid var(--border); border-radius: 16px; padding: 16px; box-shadow: 0 20px 50px rgba(0,0,0,0.5); }
     .dialog h3 { margin: 6px 0 10px; font-size: var(--font-md); }
     .toolbar { margin: 10px 0; }


### PR DESCRIPTION
## Summary
- add `role="dialog"` and `aria-modal="true"` to zone management modal
- enable smooth fade-in by transitioning modal opacity from 0 to 1

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b7dba339bc83208c870e71be3312ac