### PR TITLE
Add baseline pay and improvement visualization

### DIFF
--- a/compute.js
+++ b/compute.js
@@ -66,6 +66,14 @@ function compute({
   const finalNurse = Math.max(0, baseNurse * K);
   const finalAssist = Math.max(0, baseAssist * K);
 
+  const baseShiftDoc = Math.max(0, baseDoc * sh);
+  const baseShiftNurse = Math.max(0, baseNurse * sh);
+  const baseShiftAssist = Math.max(0, baseAssist * sh);
+
+  const baseMonthDoc = Math.max(0, baseDoc * mh);
+  const baseMonthNurse = Math.max(0, baseNurse * mh);
+  const baseMonthAssist = Math.max(0, baseAssist * mh);
+
   const shiftDoc = finalDoc * sh;
   const shiftNurse = finalNurse * sh;
   const shiftAssist = finalAssist * sh;
@@ -91,6 +99,16 @@ function compute({
       doctor: baseDoc,
       nurse: baseNurse,
       assistant: baseAssist,
+    },
+    baseline_shift_salary: {
+      doctor: baseShiftDoc,
+      nurse: baseShiftNurse,
+      assistant: baseShiftAssist,
+    },
+    baseline_month_salary: {
+      doctor: baseMonthDoc,
+      nurse: baseMonthNurse,
+      assistant: baseMonthAssist,
     },
     final_rates: {
       doctor: finalDoc,

--- a/index.html
+++ b/index.html
@@ -198,14 +198,15 @@
         <h2 class="role-heading">Tarifai pagal rolę</h2>
         <table class="table">
           <thead>
-            <tr><th>Rolė</th><th>Bazė (€/val.)</th><th>Koef. K<sub>zona</sub></th><th>Galutinis (€/val.)</th><th>Pam. alga (€/pam.)</th><th>Mėn. alga (€/mėn.)</th></tr>
+            <tr><th>Rolė</th><th>Bazė (€/val.)</th><th>Koef. K<sub>zona</sub></th><th>Galutinis (€/val.)</th><th>Pam. alga (€/pam.)</th><th>Mėn. alga (€/mėn.)</th><th>Improvement</th></tr>
           </thead>
           <tbody>
-            <tr><td>Gydytojas</td><td id="baseDocCell">€0,00</td><td id="kDocCell">1,00</td><td class="accent" id="finalDocCell">€0,00</td><td id="shiftDocCell">€0,00</td><td id="monthDocCell">€0,00</td></tr>
-            <tr><td>Slaugytojas</td><td id="baseNurseCell">€0,00</td><td id="kNurseCell">1,00</td><td class="accent" id="finalNurseCell">€0,00</td><td id="shiftNurseCell">€0,00</td><td id="monthNurseCell">€0,00</td></tr>
-            <tr><td>Padėjėjas</td><td id="baseAssistCell">€0,00</td><td id="kAssistCell">1,00</td><td class="accent" id="finalAssistCell">€0,00</td><td id="shiftAssistCell">€0,00</td><td id="monthAssistCell">€0,00</td></tr>
+            <tr><td>Gydytojas</td><td id="baseDocCell">€0,00</td><td id="kDocCell">1,00</td><td class="accent" id="finalDocCell">€0,00</td><td id="shiftDocCell">€0,00</td><td id="monthDocCell">€0,00</td><td id="deltaDocCell">€0,00 / €0,00</td></tr>
+            <tr><td>Slaugytojas</td><td id="baseNurseCell">€0,00</td><td id="kNurseCell">1,00</td><td class="accent" id="finalNurseCell">€0,00</td><td id="shiftNurseCell">€0,00</td><td id="monthNurseCell">€0,00</td><td id="deltaNurseCell">€0,00 / €0,00</td></tr>
+            <tr><td>Padėjėjas</td><td id="baseAssistCell">€0,00</td><td id="kAssistCell">1,00</td><td class="accent" id="finalAssistCell">€0,00</td><td id="shiftAssistCell">€0,00</td><td id="monthAssistCell">€0,00</td><td id="deltaAssistCell">€0,00 / €0,00</td></tr>
           </tbody>
         </table>
+        <canvas id="payChart"></canvas>
 
         <div class="footer">
           Patarimas: jei dažnai pasiekiate lubas, padidinkite zonos talpą arba sumažinkite priedų laiptelius.

--- a/tests/compute.test.js
+++ b/tests/compute.test.js
@@ -64,6 +64,27 @@ describe('compute core logic', () => {
     expect(result.K_zona).toBeCloseTo(1.30);
   });
 
+  test('returns baseline salaries without bonuses', () => {
+    const result = compute({
+      zoneCapacity: 100,
+      patientCount: 100,
+      maxCoefficient: 1.5,
+      baseDoc: 10,
+      baseNurse: 8,
+      baseAssist: 6,
+      shiftH: 12,
+      monthH: 160,
+      n1: 20,
+      n2: 20,
+      n3: 60,
+      n4: 0,
+      n5: 0,
+    });
+    expect(result.baseline_shift_salary.doctor).toBeCloseTo(120);
+    expect(result.baseline_month_salary.nurse).toBeCloseTo(1280);
+    expect(result.shift_salary.doctor).toBeGreaterThan(result.baseline_shift_salary.doctor);
+  });
+
   test('handles NaN inputs with safe defaults', () => {
     const result = compute({
       zoneCapacity: NaN,

--- a/ui.js
+++ b/ui.js
@@ -35,16 +35,19 @@ const els = {
   finalDocCell: document.getElementById('finalDocCell'),
   shiftDocCell: document.getElementById('shiftDocCell'),
   monthDocCell: document.getElementById('monthDocCell'),
+  deltaDocCell: document.getElementById('deltaDocCell'),
   baseNurseCell: document.getElementById('baseNurseCell'),
   kNurseCell: document.getElementById('kNurseCell'),
   finalNurseCell: document.getElementById('finalNurseCell'),
   shiftNurseCell: document.getElementById('shiftNurseCell'),
   monthNurseCell: document.getElementById('monthNurseCell'),
+  deltaNurseCell: document.getElementById('deltaNurseCell'),
   baseAssistCell: document.getElementById('baseAssistCell'),
   kAssistCell: document.getElementById('kAssistCell'),
   finalAssistCell: document.getElementById('finalAssistCell'),
   shiftAssistCell: document.getElementById('shiftAssistCell'),
   monthAssistCell: document.getElementById('monthAssistCell'),
+  deltaAssistCell: document.getElementById('deltaAssistCell'),
   reset: document.getElementById('reset'),
   copy: document.getElementById('copy'),
   downloadCsv: document.getElementById('downloadCsv'),
@@ -57,7 +60,8 @@ const els = {
   defaultsZones: document.getElementById('defaultsZones'),
   closeZoneModal: document.getElementById('closeZoneModal'),
   saveRateTemplate: document.getElementById('saveRateTemplate'),
-  loadRateTemplate: document.getElementById('loadRateTemplate')
+  loadRateTemplate: document.getElementById('loadRateTemplate'),
+  payCanvas: document.getElementById('payChart')
 };
 
 // Legacy aliases
@@ -102,6 +106,23 @@ if (els.sCanvas) {
     data: {
       labels: ['ESI1', 'ESI2', 'ESI3', 'ESI4', 'ESI5'],
       datasets: [{ data: [0, 0, 0, 0, 0], backgroundColor: [danger, accent2, muted, muted, muted] }]
+    },
+    options: {
+      plugins: { legend: { display: false } },
+      scales: { x: { display: false }, y: { display: false } },
+      maintainAspectRatio: false
+    }
+  });
+}
+if (els.payCanvas) {
+  charts.pay = new Chart(els.payCanvas, {
+    type: 'bar',
+    data: {
+      labels: ['Doctor', 'Nurse', 'Assistant'],
+      datasets: [
+        { label: 'Baseline', data: [0, 0, 0], backgroundColor: borderColor },
+        { label: 'Adjusted', data: [0, 0, 0], backgroundColor: accent }
+      ]
     },
     options: {
       plugins: { legend: { display: false } },
@@ -163,24 +184,40 @@ function compute(){
     charts.s.data.datasets[0].data = [n1, n2, n3, n4, n5];
     charts.s.update();
   }
+  if (charts.pay) {
+    charts.pay.data.datasets[0].data = [
+      data.baseline_shift_salary.doctor,
+      data.baseline_shift_salary.nurse,
+      data.baseline_shift_salary.assistant
+    ];
+    charts.pay.data.datasets[1].data = [
+      data.shift_salary.doctor,
+      data.shift_salary.nurse,
+      data.shift_salary.assistant
+    ];
+    charts.pay.update();
+  }
 
   els.baseDocCell.textContent = money(data.base_rates.doctor);
   els.kDocCell.textContent = data.K_zona.toFixed(2);
   els.finalDocCell.textContent = money(data.final_rates.doctor);
   els.shiftDocCell.textContent = money(data.shift_salary.doctor);
   els.monthDocCell.textContent = money(data.month_salary.doctor);
+  els.deltaDocCell.textContent = `${money(data.shift_salary.doctor - data.baseline_shift_salary.doctor)} / ${money(data.month_salary.doctor - data.baseline_month_salary.doctor)}`;
 
   els.baseNurseCell.textContent = money(data.base_rates.nurse);
   els.kNurseCell.textContent = data.K_zona.toFixed(2);
   els.finalNurseCell.textContent = money(data.final_rates.nurse);
   els.shiftNurseCell.textContent = money(data.shift_salary.nurse);
   els.monthNurseCell.textContent = money(data.month_salary.nurse);
+  els.deltaNurseCell.textContent = `${money(data.shift_salary.nurse - data.baseline_shift_salary.nurse)} / ${money(data.month_salary.nurse - data.baseline_month_salary.nurse)}`;
 
   els.baseAssistCell.textContent = money(data.base_rates.assistant);
   els.kAssistCell.textContent = data.K_zona.toFixed(2);
   els.finalAssistCell.textContent = money(data.final_rates.assistant);
   els.shiftAssistCell.textContent = money(data.shift_salary.assistant);
   els.monthAssistCell.textContent = money(data.month_salary.assistant);
+  els.deltaAssistCell.textContent = `${money(data.shift_salary.assistant - data.baseline_shift_salary.assistant)} / ${money(data.month_salary.assistant - data.baseline_month_salary.assistant)}`;
 
   return {
     date: els.date.value || null,


### PR DESCRIPTION
## Summary
- compute: return baseline shift and month salaries for each role
- UI: show improvement over baseline and small pay comparison chart
- tests: cover baseline salary calculations

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b87d6c9a40832094a0c1120f7a34a0