### PR TITLE
Refactor zone editor to avoid HTML injection

### DIFF
--- a/tests/zones.test.js
+++ b/tests/zones.test.js
@@ -1,4 +1,4 @@
-const { sanitizeId, loadZones, saveZones, DEFAULT_ZONES } = require('../zones.js');
+const { sanitizeId, loadZones, saveZones, DEFAULT_ZONES, initZones } = require('../zones.js');
 
 describe('zones utilities', () => {
   test('sanitizeId creates valid ids', () => {
@@ -12,5 +12,37 @@ describe('zones utilities', () => {
     expect(loadZones()).toEqual(custom);
     localStorage.removeItem('ED_ZONES_V2');
     expect(loadZones()).toEqual(DEFAULT_ZONES);
+  });
+});
+
+describe('renderZoneEditor', () => {
+  test('escapes user-provided data', () => {
+    localStorage.removeItem('ED_ZONES_V2');
+    const els = {
+      zoneTbody: document.createElement('tbody'),
+      zoneModal: document.createElement('div'),
+      zone: document.createElement('select'),
+      shift: document.createElement('select'),
+      zoneCapacity: document.createElement('input'),
+    };
+    els.shift.value = 'D';
+    const mod = initZones(els);
+    const zones = mod.getZones();
+    zones.splice(0, zones.length);
+    zones.push({ id: 'XSS', name: '<img src=x onerror="alert(1)">', group: '<b>G</b>', cap: { D: 1, N: 1, P: 2 } });
+
+    mod.renderZoneSelect();
+    mod.openZoneModal();
+
+    expect(els.zoneTbody.querySelector('img')).toBeNull();
+    expect(els.zoneTbody.querySelector('b')).toBeNull();
+    expect(els.zoneTbody.querySelector('input[data-field="name"]').value).toBe('<img src=x onerror="alert(1)">');
+
+    const nameInput = els.zoneTbody.querySelector('input[data-field="name"]');
+    nameInput.value = '<script>alert(1)</script>';
+    nameInput.dispatchEvent(new Event('input', { bubbles: true }));
+
+    expect(els.zone.querySelector('script')).toBeNull();
+    expect(els.zone.querySelector('option').textContent).toBe('<script>alert(1)</script>');
   });
 });

--- a/zones.js
+++ b/zones.js
@@ -95,15 +95,82 @@ export function initZones(els) {
       tr.addEventListener('dragover', onDragOver);
       tr.addEventListener('dragleave', onDragLeave);
       tr.addEventListener('drop', onDrop);
-      tr.innerHTML = `
-        <td><span class="drag-handle" title="Vilkite rikiavimui"></span></td>
-        <td><input type="text" value="${z.name}" data-idx="${idx}" data-field="name" /></td>
-        <td><input type="text" value="${z.id}" data-idx="${idx}" data-field="id" /></td>
-        <td><input type="text" value="${z.group || ''}" data-idx="${idx}" data-field="group" placeholder="pvz., Suaugusiųjų" /></td>
-        <td><input type="number" min="0" step="1" value="${z.cap?.D ?? 0}" data-idx="${idx}" data-field="capD" /></td>
-        <td><input type="number" min="0" step="1" value="${z.cap?.N ?? 0}" data-idx="${idx}" data-field="capN" /></td>
-        <td><input type="number" min="0" step="1" value="${z.cap?.P ?? 0}" data-idx="${idx}" data-field="capP" /></td>
-        <td><button data-action="del" data-idx="${idx}">Šalinti</button></td>`;
+      const tdDrag = document.createElement('td');
+      const spanDrag = document.createElement('span');
+      spanDrag.className = 'drag-handle';
+      spanDrag.title = 'Vilkite rikiavimui';
+      tdDrag.appendChild(spanDrag);
+      tr.appendChild(tdDrag);
+
+      const tdName = document.createElement('td');
+      const inpName = document.createElement('input');
+      inpName.type = 'text';
+      inpName.value = z.name;
+      inpName.dataset.idx = idx;
+      inpName.dataset.field = 'name';
+      tdName.appendChild(inpName);
+      tr.appendChild(tdName);
+
+      const tdId = document.createElement('td');
+      const inpId = document.createElement('input');
+      inpId.type = 'text';
+      inpId.value = z.id;
+      inpId.dataset.idx = idx;
+      inpId.dataset.field = 'id';
+      tdId.appendChild(inpId);
+      tr.appendChild(tdId);
+
+      const tdGroup = document.createElement('td');
+      const inpGroup = document.createElement('input');
+      inpGroup.type = 'text';
+      inpGroup.value = z.group || '';
+      inpGroup.dataset.idx = idx;
+      inpGroup.dataset.field = 'group';
+      inpGroup.placeholder = 'pvz., Suaugusiųjų';
+      tdGroup.appendChild(inpGroup);
+      tr.appendChild(tdGroup);
+
+      const tdCapD = document.createElement('td');
+      const inpCapD = document.createElement('input');
+      inpCapD.type = 'number';
+      inpCapD.min = '0';
+      inpCapD.step = '1';
+      inpCapD.value = z.cap?.D ?? 0;
+      inpCapD.dataset.idx = idx;
+      inpCapD.dataset.field = 'capD';
+      tdCapD.appendChild(inpCapD);
+      tr.appendChild(tdCapD);
+
+      const tdCapN = document.createElement('td');
+      const inpCapN = document.createElement('input');
+      inpCapN.type = 'number';
+      inpCapN.min = '0';
+      inpCapN.step = '1';
+      inpCapN.value = z.cap?.N ?? 0;
+      inpCapN.dataset.idx = idx;
+      inpCapN.dataset.field = 'capN';
+      tdCapN.appendChild(inpCapN);
+      tr.appendChild(tdCapN);
+
+      const tdCapP = document.createElement('td');
+      const inpCapP = document.createElement('input');
+      inpCapP.type = 'number';
+      inpCapP.min = '0';
+      inpCapP.step = '1';
+      inpCapP.value = z.cap?.P ?? 0;
+      inpCapP.dataset.idx = idx;
+      inpCapP.dataset.field = 'capP';
+      tdCapP.appendChild(inpCapP);
+      tr.appendChild(tdCapP);
+
+      const tdDel = document.createElement('td');
+      const btnDel = document.createElement('button');
+      btnDel.dataset.action = 'del';
+      btnDel.dataset.idx = idx;
+      btnDel.textContent = 'Šalinti';
+      tdDel.appendChild(btnDel);
+      tr.appendChild(tdDel);
+
       els.zoneTbody.appendChild(tr);
     });
 


### PR DESCRIPTION
## Summary
- Build zone editor table using DOM APIs instead of innerHTML
- Insert zone data with textContent/value to avoid running user markup
- Add test verifying malicious zone names do not create markup

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b8820e71548320a3f545fb9b1a2c84