### PR TITLE
Handle chart initialization errors and destroyed charts

### DIFF
--- a/ui.js
+++ b/ui.js
@@ -86,59 +86,71 @@ const muted = style.getPropertyValue('--muted').trim();
 const charts = {};
 if (els.ratioCanvas) {
   if (typeof Chart !== 'undefined') {
-    charts.ratio = new Chart(els.ratioCanvas, {
-      type: 'doughnut',
-      data: {
-        labels: ['Pacientų skaičius', 'Likutis'],
-        datasets: [{ data: [0, 1], backgroundColor: [accent, borderColor], borderWidth: 0 }]
-      },
-      options: {
-        rotation: -90,
-        circumference: 180,
-        cutout: '70%',
-        plugins: { legend: { display: false }, tooltip: { enabled: false } },
-        maintainAspectRatio: false
-      }
-    });
+    try {
+      charts.ratio = new Chart(els.ratioCanvas, {
+        type: 'doughnut',
+        data: {
+          labels: ['Pacientų skaičius', 'Likutis'],
+          datasets: [{ data: [0, 1], backgroundColor: [accent, borderColor], borderWidth: 0 }]
+        },
+        options: {
+          rotation: -90,
+          circumference: 180,
+          cutout: '70%',
+          plugins: { legend: { display: false }, tooltip: { enabled: false } },
+          maintainAspectRatio: false
+        }
+      });
+    } catch (err) {
+      console.error('Failed to create ratio chart:', err);
+    }
   } else {
     console.warn('Chart.js not available: ratio chart skipped');
   }
 }
 if (els.sCanvas) {
   if (typeof Chart !== 'undefined') {
-    charts.s = new Chart(els.sCanvas, {
-      type: 'bar',
-      data: {
-        labels: ['ESI1', 'ESI2', 'ESI3', 'ESI4', 'ESI5'],
-        datasets: [{ data: [0, 0, 0, 0, 0], backgroundColor: [danger, accent2, muted, muted, muted] }]
-      },
-      options: {
-        plugins: { legend: { display: false } },
-        scales: { x: { display: false }, y: { display: false } },
-        maintainAspectRatio: false
-      }
-    });
+    try {
+      charts.s = new Chart(els.sCanvas, {
+        type: 'bar',
+        data: {
+          labels: ['ESI1', 'ESI2', 'ESI3', 'ESI4', 'ESI5'],
+          datasets: [{ data: [0, 0, 0, 0, 0], backgroundColor: [danger, accent2, muted, muted, muted] }]
+        },
+        options: {
+          plugins: { legend: { display: false } },
+          scales: { x: { display: false }, y: { display: false } },
+          maintainAspectRatio: false
+        }
+      });
+    } catch (err) {
+      console.error('Failed to create s chart:', err);
+    }
   } else {
     console.warn('Chart.js not available: s chart skipped');
   }
 }
 if (els.payCanvas) {
   if (typeof Chart !== 'undefined') {
-    charts.pay = new Chart(els.payCanvas, {
-      type: 'bar',
-      data: {
-        labels: ['Doctor', 'Nurse', 'Assistant'],
-        datasets: [
-          { label: 'Baseline', data: [0, 0, 0], backgroundColor: borderColor },
-          { label: 'Adjusted', data: [0, 0, 0], backgroundColor: accent }
-        ]
-      },
-      options: {
-        plugins: { legend: { display: false } },
-        scales: { x: { display: false }, y: { display: false } },
-        maintainAspectRatio: false
-      }
-    });
+    try {
+      charts.pay = new Chart(els.payCanvas, {
+        type: 'bar',
+        data: {
+          labels: ['Doctor', 'Nurse', 'Assistant'],
+          datasets: [
+            { label: 'Baseline', data: [0, 0, 0], backgroundColor: borderColor },
+            { label: 'Adjusted', data: [0, 0, 0], backgroundColor: accent }
+          ]
+        },
+        options: {
+          plugins: { legend: { display: false } },
+          scales: { x: { display: false }, y: { display: false } },
+          maintainAspectRatio: false
+        }
+      });
+    } catch (err) {
+      console.error('Failed to create pay chart:', err);
+    }
   } else {
     console.warn('Chart.js not available: pay chart skipped');
   }
@@ -188,15 +200,15 @@ function compute(){
   els.maxCoefficientCell.textContent = data.maxCoefficient.toFixed(2);
   els.kZona.textContent = data.K_zona.toFixed(2);
 
-  if (charts.ratio) {
+  if (charts.ratio && !charts.ratio.destroyed) {
     charts.ratio.data.datasets[0].data = [Math.min(data.patientCount, zoneCapacity), Math.max(zoneCapacity - Math.min(data.patientCount, zoneCapacity), 0)];
     charts.ratio.update();
   }
-  if (charts.s) {
+  if (charts.s && !charts.s.destroyed) {
     charts.s.data.datasets[0].data = [n1, n2, n3, n4, n5];
     charts.s.update();
   }
-  if (charts.pay) {
+  if (charts.pay && !charts.pay.destroyed) {
     charts.pay.data.datasets[0].data = [
       data.baseline_shift_salary.doctor,
       data.baseline_shift_salary.nurse,


### PR DESCRIPTION
## Summary
- Wrap Chart initialization for ratio, s, and pay charts in try/catch blocks and log failures
- Skip updating charts that failed to initialize or have been destroyed

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b885cb7f408320b18f9aeea78745a4