### PR TITLE
Pin Chart.js to version 4.4.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,10 @@ You can also enter shift length and total monthly hours to see estimated earning
 2. Open `index.html` in a modern web browser.
 3. Fill in the form to see calculated coefficients and final rates.
 
+## Dependencies
+
+This project loads [Chart.js](https://www.chartjs.org/) from a CDN and pins it to version **4.4.0**. Update the version string deliberately when upgrading to avoid unexpected changes.
+
 ## Testing
 
 Install dependencies and run the Jest test suite:

--- a/index.html
+++ b/index.html
@@ -245,8 +245,8 @@
       <div class="help small">Pastaba: <strong>Kodas</strong> turi būti unikalus (pvz., RED, YEL, GRN). Grupę galite įvesti savo (pvz., „Suaugusiųjų“, „Vaikų“).</div>
     </div>
   </div>
-
-    <script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
+    <!-- Chart.js v4.4.0 pinned to avoid unexpected breaking changes -->
+    <script src="https://cdn.jsdelivr.net/npm/chart.js@4.4.0"></script>
     <script src="https://cdn.jsdelivr.net/npm/jspdf@2.5.1/dist/jspdf.umd.min.js"></script>
     <script src="compute.js" defer></script>
     <script src="csv.js" defer></script>


### PR DESCRIPTION
## Summary
- Pin Chart.js CDN import to version 4.4.0 to avoid unintended upgrades
- Document chosen Chart.js version in README for deliberate updates

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b886a94834832090dcaeb16fdd4b67