### PR TITLE
style: constrain pay chart dimensions

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -95,6 +95,14 @@
     .table th, .table td { padding: 8px 10px; border-bottom: 1px solid var(--border); text-align: left; }
     .table th { color: var(--muted); font-weight: 600; }
 
+    #payChart {
+      width: 100%;
+      max-width: 480px;
+      height: 240px;
+      margin: 16px auto 0;
+      display: block;
+    }
+
     .footer { margin-top: 18px; font-size: var(--font-xs); color: var(--muted); }
 
     /* Modal */


### PR DESCRIPTION
## Summary
- size pay rate chart consistently by adding explicit height, max-width, and centering

## Testing
- `npm test`
- Verified payChart height in default and light themes using JSDOM

------
https://chatgpt.com/codex/tasks/task_e_68b88a80fa80832088b4bd61614be366