### PR TITLE
refactor: switch compute to ES module

### DIFF
--- a/compute.js
+++ b/compute.js
@@ -128,12 +128,4 @@ function compute({
   };
 }
 
-const exported = { THRESHOLDS, getBonus, compute };
-
-if (typeof module !== 'undefined') {
-  module.exports = exported;
-}
-
-if (typeof window !== 'undefined') {
-  window.computeCore = exported;
-}
+export { compute };

--- a/index.html
+++ b/index.html
@@ -248,7 +248,6 @@
     <!-- Chart.js v4.4.0 pinned to avoid unexpected breaking changes -->
     <script src="https://cdn.jsdelivr.net/npm/chart.js@4.4.0"></script>
     <script src="https://cdn.jsdelivr.net/npm/jspdf@2.5.1/dist/jspdf.umd.min.js"></script>
-    <script src="compute.js" defer></script>
     <script src="csv.js" defer></script>
     <script src="pdf.js" defer></script>
     <script type="module" src="ui.js"></script>

--- a/ui.js
+++ b/ui.js
@@ -1,6 +1,7 @@
 import { initThemeToggle } from './theme.js';
 import { initZones } from './zones.js';
 import { downloadCsv, downloadPdf } from './downloads.js';
+import { compute as coreCompute } from './compute.js';
 
 const LS_RATE_KEY = 'ED_RATE_TEMPLATE_V2';
 
@@ -177,7 +178,7 @@ function compute(){
   let patientCount = Math.max(0, toNum(els.patientCount.value));
   if (els.linkPatientCount.checked){ patientCount = n1 + n2 + n3 + n4 + n5; els.patientCount.value = patientCount; els.patientCount.disabled = true; } else els.patientCount.disabled = false;
 
-  const data = computeCore.compute({
+  const data = coreCompute({
     zoneCapacity,
     maxCoefficient,
     baseDoc,


### PR DESCRIPTION
## Summary
- refactor compute.js into an ES module exporting `compute`
- import compute into ui.js and replace old `computeCore` usage
- drop standalone compute.js script from index.html

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b88f0e9ec48320860a75bf3c754649