### PR TITLE
fix: set canvas dimensions via attributes

### DIFF
--- a/index.html
+++ b/index.html
@@ -206,7 +206,7 @@
             <tr><td>Padėjėjas</td><td id="baseAssistCell">€0,00</td><td id="kAssistCell">1,00</td><td class="accent" id="finalAssistCell">€0,00</td><td id="shiftAssistCell">€0,00</td><td id="monthAssistCell">€0,00</td><td id="deltaAssistCell">€0,00 / €0,00</td></tr>
           </tbody>
         </table>
-        <canvas id="payChart"></canvas>
+        <canvas id="payChart" width="480" height="240"></canvas>
 
         <div class="footer">
           Patarimas: jei dažnai pasiekiate lubas, padidinkite zonos talpą arba sumažinkite priedų laiptelius.

--- a/styles.css
+++ b/styles.css
@@ -96,9 +96,7 @@
     .table th { color: var(--muted); font-weight: 600; }
 
     #payChart {
-      width: 100%;
-      max-width: 480px;
-      height: 240px;
+      max-width: 100%;
       margin: 16px auto 0;
       display: block;
     }


### PR DESCRIPTION
## Summary
- set explicit width/height on pay chart canvas
- drop conflicting CSS sizing rules to rely on HTML attributes

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b8928210008320b178fac027cdce70