### PR TITLE
Embed charts in PDF and add summary sections

### DIFF
--- a/downloads.js
+++ b/downloads.js
@@ -49,7 +49,28 @@ export function downloadCsv(data) {
 }
 
 export function buildPdf(data) {
-  return pdfUtils.generatePdf(data);
+  const chartImages = {};
+  if (typeof document !== 'undefined' && typeof Chart !== 'undefined') {
+    ['ratioChart', 'sChart', 'payChart'].forEach(id => {
+      const canvas = document.getElementById(id);
+      if (canvas) {
+        let chart;
+        if (typeof Chart.getChart === 'function') {
+          chart = Chart.getChart(canvas);
+        } else if (canvas.chart) {
+          chart = canvas.chart;
+        }
+        if (chart && typeof chart.toBase64Image === 'function') {
+          try {
+            chartImages[id] = chart.toBase64Image();
+          } catch (err) {
+            console.error('Failed to capture chart', id, err);
+          }
+        }
+      }
+    });
+  }
+  return pdfUtils.generatePdf(data, chartImages);
 }
 
 export function downloadPdf(data) {

--- a/pdf.js
+++ b/pdf.js
@@ -16,7 +16,7 @@ if (!jsPDFLib) {
   }
 }
 
-function generatePdf(data) {
+function generatePdf(data, chartImages = {}) {
   if (!jsPDFLib) {
     throw new Error('jsPDF library is not loaded');
   }
@@ -71,6 +71,59 @@ function generatePdf(data) {
     );
     y += 5;
   });
+
+  y += 5;
+  doc.setFontSize(12);
+  doc.text('Summary', margin, y);
+  y += 6;
+  doc.setFontSize(10);
+  ['doctor','nurse','assistant'].forEach(role => {
+    const base = data.baseline_shift_salary[role];
+    const final = data.shift_salary[role];
+    const diff = final - base;
+    doc.text(
+      `${role}: baseline ${base.toFixed(2)} → adjusted ${final.toFixed(2)} (Δ ${diff.toFixed(2)})`,
+      margin,
+      y
+    );
+    y += 5;
+  });
+  doc.text(
+    `Bonuses reward volume (V_bonus ${data.V_bonus.toFixed(2)}), acuity (A_bonus ${data.A_bonus.toFixed(2)}) and zone difficulty (K_zona ${data.K_zona.toFixed(2)}).`,
+    margin,
+    y
+  );
+  y += 10;
+
+  const chartIds = Object.keys(chartImages);
+  if (chartIds.length) {
+    const imgWidth = 60;
+    const imgHeight = 40;
+    chartIds.forEach((id, idx) => {
+      const img = chartImages[id];
+      const x = margin + (idx % 2) * (imgWidth + 10);
+      const yPos = y + Math.floor(idx / 2) * (imgHeight + 10);
+      try {
+        doc.addImage(img, 'PNG', x, yPos, imgWidth, imgHeight);
+      } catch (err) {
+        console.error('Failed to add image', id, err);
+      }
+    });
+    y += Math.ceil(chartIds.length / 2) * (imgHeight + 10);
+  }
+
+  doc.addPage();
+  y = margin;
+  doc.setFontSize(16);
+  doc.text("Director's Brief", margin, y);
+  y += 10;
+  doc.setFontSize(12);
+  const brief = [
+    'Aligns pay with workload and patient acuity.',
+    'Encourages efficiency and quality care.',
+    'Provides transparent, data-driven bonuses.',
+  ];
+  brief.forEach(line => { doc.text(`• ${line}`, margin, y); y += 8; });
 
   return doc;
 }

--- a/tests/pdf.test.js
+++ b/tests/pdf.test.js
@@ -29,4 +29,32 @@ describe('PDF generation', () => {
     expect(doc).toBeDefined();
     expect(typeof doc.save).toBe('function');
   });
+
+  test('handles chart images', () => {
+    const data = compute({
+      zoneCapacity: 5,
+      maxCoefficient: 1.1,
+      baseDoc: 10,
+      baseNurse: 5,
+      baseAssist: 2,
+      shiftH: 12,
+      monthH: 160,
+      n1: 1,
+      n2: 1,
+      n3: 1,
+      n4: 1,
+      n5: 1,
+      patientCount: undefined,
+    });
+    const dummyImg = 'data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mP8Xw8AAn8B9M6P7wAAAABJRU5ErkJggg==';
+    const doc = generatePdf({
+      date: '2024-02-02',
+      shift: 'D',
+      zone: 'Z',
+      zone_label: 'Zone Z',
+      zoneCapacity: 5,
+      ...data,
+    }, { ratioChart: dummyImg, sChart: dummyImg, payChart: dummyImg });
+    expect(doc).toBeDefined();
+  });
 });


### PR DESCRIPTION
## Summary
- capture Chart.js canvases as base64 images and embed them in PDFs
- extend PDF with salary summary and bonus explanations
- add a Director's brief page outlining motivation system benefits

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b90d7d3f9c83209467da22e4fb306a