### PR TITLE
refactor: drop _destroyed check

### DIFF
--- a/chart-utils.js
+++ b/chart-utils.js
@@ -1,0 +1,9 @@
+export function updateChart(chart, updater) {
+  if (!chart || typeof chart.update !== 'function') return;
+  updater(chart);
+}
+
+// CommonJS support for tests
+if (typeof module !== 'undefined') {
+  module.exports = { updateChart };
+}

--- a/tests/chart-utils.test.js
+++ b/tests/chart-utils.test.js
@@ -1,0 +1,24 @@
+import { updateChart } from '../chart-utils.js';
+
+describe('updateChart', () => {
+  test('calls updater when chart is valid', () => {
+    const chart = { update: jest.fn() };
+    const updater = jest.fn(c => c.update());
+    updateChart(chart, updater);
+    expect(updater).toHaveBeenCalledWith(chart);
+    expect(chart.update).toHaveBeenCalled();
+  });
+
+  test('skips update when chart is null', () => {
+    const updater = jest.fn();
+    updateChart(null, updater);
+    expect(updater).not.toHaveBeenCalled();
+  });
+
+  test('skips update when update method missing', () => {
+    const chart = {};
+    const updater = jest.fn();
+    updateChart(chart, updater);
+    expect(updater).not.toHaveBeenCalled();
+  });
+});

--- a/ui.js
+++ b/ui.js
@@ -2,6 +2,7 @@ import { initThemeToggle } from './theme.js';
 import { initZones } from './zones.js';
 import { downloadCsv, downloadPdf } from './downloads.js';
 import { compute as coreCompute } from './compute.js';
+import { updateChart } from './chart-utils.js';
 
 const LS_RATE_KEY = 'ED_RATE_TEMPLATE_V2';
 
@@ -161,10 +162,6 @@ function toNum(v){ const n = Number(v); return Number.isFinite(n) ? n : 0; }
 function fmt(n, d=2){ return (Number.isFinite(n) ? n : 0).toFixed(d); }
 function money(n){ try{ return new Intl.NumberFormat('lt-LT',{style:'currency',currency:'EUR'}).format(n||0); }catch{ return `€${fmt(n)}`; } }
 
-function updateChart(chart, updater){
-  if (!chart || chart._destroyed) return;
-  updater(chart);
-}
 
 function compute(){
   const zoneCapacity = Math.max(0, toNum(els.zoneCapacity.value));


### PR DESCRIPTION
## Summary
- replace `_destroyed` flag checks with `update` function validation in new `updateChart` helper
- use helper in `ui.js`
- add unit tests for chart updating logic

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b9248d84248320b62eb9b5ede6e537