### PR TITLE
Fix chart sizing for consistent dimensions

### DIFF
--- a/index.html
+++ b/index.html
@@ -152,13 +152,13 @@
           <div class="item">
             <div class="label">Santykis Pacientų skaičius/Zonos talpa</div>
             <div class="val" id="ratio">0.00</div>
-            <canvas id="ratioChart"></canvas>
+            <canvas id="ratioChart" width="480" height="240"></canvas>
             <div class="help">Apkrovos intervalas lemia V<sub>priedas</sub></div>
           </div>
           <div class="item">
             <div class="label">Aukštos skubos dalis S = (ESI1+ESI2)/Pacientų skaičius</div>
             <div class="val" id="sShare">0.00</div>
-            <canvas id="sChart"></canvas>
+            <canvas id="sChart" width="480" height="240"></canvas>
             <div class="help">Lemia A<sub>priedas</sub></div>
           </div>
         </div>

--- a/ui.js
+++ b/ui.js
@@ -102,7 +102,8 @@ if (els.ratioCanvas) {
             circumference: 180,
             cutout: '70%',
             plugins: { legend: { display: false }, tooltip: { enabled: false } },
-            maintainAspectRatio: false
+            maintainAspectRatio: false,
+            responsive: false
           }
         });
       }
@@ -127,7 +128,8 @@ if (els.sCanvas) {
           options: {
             plugins: { legend: { display: false } },
             scales: { x: { display: false }, y: { display: false } },
-            maintainAspectRatio: false
+            maintainAspectRatio: false,
+            responsive: false
           }
         });
       }
@@ -155,7 +157,8 @@ if (els.payCanvas) {
           options: {
             plugins: { legend: { display: false } },
             scales: { x: { display: false }, y: { display: false } },
-            maintainAspectRatio: false
+            maintainAspectRatio: false,
+            responsive: false
           }
         });
       }


### PR DESCRIPTION
## Summary
- disable Chart.js responsive behavior in ratio, s, and pay charts
- size ratio and S charts explicitly like pay chart

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b92ab6af3483209af0d2cb4f4e8e16