### PR TITLE
chore: bump Chart.js CDN

### DIFF
--- a/index.html
+++ b/index.html
@@ -245,8 +245,8 @@
       <div class="help small">Pastaba: <strong>Kodas</strong> turi būti unikalus (pvz., RED, YEL, GRN). Grupę galite įvesti savo (pvz., „Suaugusiųjų“, „Vaikų“).</div>
     </div>
   </div>
-    <!-- Chart.js v4.4.0 pinned to avoid unexpected breaking changes -->
-    <script src="https://cdn.jsdelivr.net/npm/chart.js@4.4.0"></script>
+    <!-- Chart.js v4.4.9 pinned to avoid unexpected breaking changes -->
+    <script src="https://cdn.jsdelivr.net/npm/chart.js@4.4.9?v=4.4.9"></script>
     <script src="https://cdn.jsdelivr.net/npm/jspdf@2.5.1/dist/jspdf.umd.min.js"></script>
     <script src="csv.js" defer></script>
     <script src="pdf.js" defer></script>


### PR DESCRIPTION
## Summary
- update Chart.js CDN to latest 4.4.9 patch with cache busting

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b92dd8cad08320877f069665edfca3