### PR TITLE
Improve chart error handling

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -95,11 +95,17 @@
     .table th, .table td { padding: 8px 10px; border-bottom: 1px solid var(--border); text-align: left; }
     .table th { color: var(--muted); font-weight: 600; }
 
-    #payChart {
-      max-width: 100%;
-      margin: 16px auto 0;
-      display: block;
-    }
+#payChart {
+  max-width: 100%;
+  margin: 16px auto 0;
+  display: block;
+}
+
+.chart-error {
+  color: var(--danger);
+  text-align: center;
+  padding: 16px;
+}
 
     .footer { margin-top: 18px; font-size: var(--font-xs); color: var(--muted); }
 

--- a/ui.js
+++ b/ui.js
@@ -85,6 +85,17 @@ const danger = style.getPropertyValue('--danger').trim();
 const accent2 = style.getPropertyValue('--accent-2').trim();
 const muted = style.getPropertyValue('--muted').trim();
 
+function handleChartError(canvas, name, err) {
+  const id = canvas && canvas.id ? `#${canvas.id}` : '';
+  console.error(`Failed to create ${name} chart (${id})`, err?.stack || err);
+  if (canvas) {
+    const msg = document.createElement('div');
+    msg.className = 'chart-error';
+    msg.textContent = `Unable to render ${name} chart`;
+    canvas.replaceWith(msg);
+  }
+}
+
 const charts = {};
 if (els.ratioCanvas) {
   if (typeof Chart !== 'undefined') {
@@ -108,7 +119,7 @@ if (els.ratioCanvas) {
         });
       }
     } catch (err) {
-      console.error('Failed to create ratio chart:', err);
+      handleChartError(els.ratioCanvas, 'ratio', err);
     }
   } else {
     console.warn('Chart.js not available: ratio chart skipped');
@@ -134,7 +145,7 @@ if (els.sCanvas) {
         });
       }
     } catch (err) {
-      console.error('Failed to create s chart:', err);
+      handleChartError(els.sCanvas, 's', err);
     }
   } else {
     console.warn('Chart.js not available: s chart skipped');
@@ -163,7 +174,7 @@ if (els.payCanvas) {
         });
       }
     } catch (err) {
-      console.error('Failed to create pay chart:', err);
+      handleChartError(els.payCanvas, 'pay', err);
     }
   } else {
     console.warn('Chart.js not available: pay chart skipped');


### PR DESCRIPTION
## Summary
- Centralize chart error handling to log canvas ID and stack trace
- Show user-friendly message if chart initialization fails
- Add styling for chart error placeholders

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b92e76dfe48320ae368e420b77328e