### PR TITLE
Show pay chart values and fix overflow

### DIFF
--- a/index.html
+++ b/index.html
@@ -163,7 +163,7 @@
           </div>
           <div class="item pay-chart">
             <div class="label">Tarifų grafikas</div>
-            <canvas id="payChart" width="480" height="240"></canvas>
+            <canvas id="payChart"></canvas>
           </div>
         </div>
 

--- a/ui.js
+++ b/ui.js
@@ -84,6 +84,7 @@ const borderColor = style.getPropertyValue('--border').trim();
 const danger = style.getPropertyValue('--danger').trim();
 const accent2 = style.getPropertyValue('--accent-2').trim();
 const muted = style.getPropertyValue('--muted').trim();
+const textColor = style.getPropertyValue('--text').trim();
 
 function handleChartError(canvas, name, err) {
   const id = canvas && canvas.id ? `#${canvas.id}` : '';
@@ -156,6 +157,25 @@ if (els.payCanvas) {
     try {
       const ctx = els.payCanvas.getContext && els.payCanvas.getContext('2d');
       if (ctx) {
+        const barValuePlugin = {
+          id: 'barValue',
+          afterDatasetsDraw(chart) {
+            const { ctx: c } = chart;
+            c.save();
+            chart.data.datasets.forEach((dataset, i) => {
+              const meta = chart.getDatasetMeta(i);
+              meta.data.forEach((bar, idx) => {
+                const val = dataset.data[idx];
+                c.fillStyle = textColor;
+                c.textAlign = 'center';
+                c.textBaseline = 'bottom';
+                c.font = '12px sans-serif';
+                c.fillText(money(val), bar.x, bar.y - 4);
+              });
+            });
+            c.restore();
+          }
+        };
         charts.pay = new Chart(ctx, {
           type: 'bar',
           data: {
@@ -166,11 +186,12 @@ if (els.payCanvas) {
             ]
           },
           options: {
-            plugins: { legend: { display: false } },
+            plugins: { legend: { display: false }, tooltip: { enabled: false } },
             scales: { x: { display: false }, y: { display: false } },
             maintainAspectRatio: false,
-            responsive: false
-          }
+            responsive: true
+          },
+          plugins: [barValuePlugin]
         });
       }
     } catch (err) {


### PR DESCRIPTION
## Summary
- display Tarifų grafikas bar values directly using a custom Chart.js plugin
- make the Tarifų grafikas responsive and remove fixed canvas size to prevent overflow when more charts are added

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b932e9e5dc8320977d944b3654f213