### PR TITLE
Expand pay chart card to full width on large screens

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -81,6 +81,7 @@
     .kpi .val { font-size: var(--font-lg); font-weight: 700; margin-top: 2px; }
     .kpi canvas { width: 100%; max-width: 120px; height: 60px !important; margin-top: 8px; }
     .kpi .pay-chart canvas { max-width: none; height: 200px !important; }
+    @media (min-width: 960px) { .kpi .pay-chart { grid-column: 1 / -1; } }
     .pill { display:inline-block; padding: 4px 8px; border-radius: 999px; font-size: var(--font-xs); border:1px solid var(--border); background:var(--panel); }
     .accent { color: var(--accent); }
     .muted { color: var(--muted); }


### PR DESCRIPTION
## Summary
- span the pay chart card across all columns on wide screens

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b935b50afc8320b19f68b1ba8386c1