### PR TITLE
Set default size for pay chart canvas

### DIFF
--- a/index.html
+++ b/index.html
@@ -163,7 +163,7 @@
           </div>
           <div class="item pay-chart">
             <div class="label">Tarifų grafikas</div>
-            <canvas id="payChart"></canvas>
+            <canvas id="payChart" width="480" height="240"></canvas>
           </div>
         </div>
 

--- a/styles.css
+++ b/styles.css
@@ -80,7 +80,7 @@
     .kpi .label { font-size: var(--font-xs); color: var(--muted); }
     .kpi .val { font-size: var(--font-lg); font-weight: 700; margin-top: 2px; }
     .kpi canvas { width: 100%; max-width: 120px; height: 60px !important; margin-top: 8px; }
-    .kpi .pay-chart canvas { max-width: none; height: 200px !important; }
+    .kpi .pay-chart canvas { max-width: none; height: 240px !important; }
     @media (min-width: 960px) { .kpi .pay-chart { grid-column: 1 / -1; } }
     .pill { display:inline-block; padding: 4px 8px; border-radius: 999px; font-size: var(--font-xs); border:1px solid var(--border); background:var(--panel); }
     .accent { color: var(--accent); }


### PR DESCRIPTION
## Summary
- Set 480x240 default dimensions for `#payChart` canvas.
- Updated CSS to match new chart height.

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b936cda300832099bd82790cac9479