### PR TITLE
Configure chart bar and category percentages

### DIFF
--- a/ui.js
+++ b/ui.js
@@ -189,7 +189,8 @@ if (els.payCanvas) {
             plugins: { legend: { display: false }, tooltip: { enabled: false } },
             scales: { x: { display: false }, y: { display: false } },
             maintainAspectRatio: false,
-            responsive: true
+            responsive: true,
+            datasets: { barPercentage: 0.6, categoryPercentage: 0.5 }
           },
           plugins: [barValuePlugin]
         });


### PR DESCRIPTION
## Summary
- configure pay chart to use explicit bar and category widths

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b93fadf1d88320b2c62869c75bc827