### PR TITLE
Fix pay chart label overflow

### DIFF
--- a/ui.js
+++ b/ui.js
@@ -168,9 +168,15 @@ if (els.payCanvas) {
                 const val = dataset.data[idx];
                 c.fillStyle = textColor;
                 c.textAlign = 'center';
-                c.textBaseline = 'bottom';
                 c.font = '12px sans-serif';
-                c.fillText(money(val), bar.x, bar.y - 4);
+                let y = bar.y - 4;
+                let baseline = 'bottom';
+                if (y < 12) {
+                  y = bar.y + 12;
+                  baseline = 'top';
+                }
+                c.textBaseline = baseline;
+                c.fillText(money(val), bar.x, y);
               });
             });
             c.restore();


### PR DESCRIPTION
## Summary
- prevent pay chart labels from rendering above canvas

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b94168b0a483208a32d07d9598faab