### PR TITLE
Reduce top spacing for header

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -41,8 +41,8 @@
       background: linear-gradient(135deg, var(--bg), #f1f5f9 60%, #e2e8f0);
       color: var(--text);
     }
-    .container { width: 100%; max-width: none; margin: 24px 0; padding: 16px; }
-    .header { display: flex; justify-content: flex-end; margin: 8px auto; padding: 8px 16px; }
+    .container { width: 100%; max-width: none; margin: 0 0 24px; padding: 16px; }
+    .header { display: flex; justify-content: flex-end; margin: 0 auto 8px; padding: 8px 16px; }
     .header + .container { margin-top: 0; }
     .title { display: flex; align-items: center; gap: 12px; flex-wrap: wrap; }
     .grid { display: grid; gap: 14px; }


### PR DESCRIPTION
## Summary
- reduce `.container` top margin and adjust header spacing for full-screen layout

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b9449e48c4832086272952ba3daf59