### PR TITLE
Reduce header spacing for compact layout

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -42,7 +42,7 @@
       color: var(--text);
     }
     .container { width: 100%; max-width: none; margin: 0 0 24px; padding: 16px; }
-    .header { display: flex; justify-content: flex-end; margin: 0 auto 8px; padding: 8px 16px; }
+    .header { display: flex; justify-content: flex-end; margin: 0 auto 4px; padding: 4px 8px; }
     .header + .container { margin-top: 0; }
     .title { display: flex; align-items: center; gap: 12px; flex-wrap: wrap; }
     .grid { display: grid; gap: 14px; }


### PR DESCRIPTION
## Summary
- Shrink header padding and margin so the header container is more compact

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b94628ed588320a82d965077c0fa85