### PR TITLE
Align theme toggle with page header

### DIFF
--- a/index.html
+++ b/index.html
@@ -7,15 +7,13 @@
   <link rel="stylesheet" href="styles.css">
   </head>
 <body>
-  <header class="container header">
-    <label class="switch">
-      <input id="themeToggle" type="checkbox" />
-      <span>Šviesi tema</span>
-    </label>
-  </header>
   <div class="container">
     <div class="title">
       <h1>Zoninio Koeficiento Skaičiuoklė</h1>
+      <label class="switch">
+        <input id="themeToggle" type="checkbox" />
+        <span>Šviesi tema</span>
+      </label>
     </div>
 
     <div class="grid grid-2">

--- a/styles.css
+++ b/styles.css
@@ -42,9 +42,8 @@
       color: var(--text);
     }
     .container { width: 100%; max-width: none; margin: 0 0 24px; padding: 16px; }
-    .header { display: flex; justify-content: flex-end; margin: 0 auto 4px; padding: 4px 8px; }
-    .header + .container { margin-top: 0; }
     .title { display: flex; align-items: center; gap: 12px; flex-wrap: wrap; }
+    .title .switch { margin-left: auto; }
     .grid { display: grid; gap: 14px; }
     @media (min-width: 960px) { .grid-2 { grid-template-columns: 1.2fr 0.8fr; } }
     .card {


### PR DESCRIPTION
## Summary
- Place light mode toggle next to main page title
- Style title container to push theme switch to the right

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b947c856dc832095187b57a1a6f77c