### PR TITLE
feat: add full-screen layout

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -30,27 +30,44 @@
       --drag: #cbd5e1;      /* slate-300 */
     }
     * { box-sizing: border-box; }
-    html, body { height: 100%; }
+    html, body { height: 100%; overflow: hidden; }
     body {
       margin: 0; font-family: system-ui, -apple-system, Segoe UI, Roboto, Ubuntu, "Helvetica Neue", Arial;
       background: linear-gradient(135deg, var(--bg), #0b1020 60%, #0a0f1a);
       color: var(--text);
+      display: flex;
+      flex-direction: column;
     }
 
     .light-theme body {
       background: linear-gradient(135deg, var(--bg), #f1f5f9 60%, #e2e8f0);
       color: var(--text);
     }
-    .container { width: 100%; max-width: none; margin: 0 0 24px; padding: 16px; }
-    .title { display: flex; align-items: center; gap: 12px; flex-wrap: wrap; }
+    .container {
+      width: 100%;
+      max-width: none;
+      margin: 0;
+      padding: 16px;
+      flex: 1;
+      display: flex;
+      flex-direction: column;
+      overflow: hidden;
+    }
+    .title { display: flex; align-items: center; gap: 12px; flex-wrap: wrap; flex-shrink: 0; }
     .title .switch { margin-left: auto; }
-    .grid { display: grid; gap: 14px; }
+    .grid {
+      display: grid;
+      gap: 14px;
+      flex: 1;
+      overflow: hidden;
+    }
     @media (min-width: 960px) { .grid-2 { grid-template-columns: 1.2fr 0.8fr; } }
     .card {
       background: radial-gradient(1200px 400px at 10% 0%, var(--panel), var(--card));
       border: 1px solid var(--border);
       border-radius: 16px; padding: 18px;
       box-shadow: 0 10px 30px rgba(0,0,0,0.35), inset 0 1px 0 rgba(255,255,255,0.02);
+      overflow: auto;
     }
     h1 { font-size: var(--font-xl); margin: 6px 0 2px; letter-spacing: 0.2px; }
     h2 { font-size: var(--font-base); margin: 0 0 10px; color: var(--muted); font-weight: 600; letter-spacing: 0.2px; }


### PR DESCRIPTION
## Summary
- make page container span the full viewport
- allow input and results panels to scroll independently

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b948dc09f8832095396e0f645f7023