### PR TITLE
Refactor simulation and randomize patient count

### DIFF
--- a/simulation.js
+++ b/simulation.js
@@ -1,0 +1,27 @@
+function simulateEsiCounts(patientCount, zoneCapacity){
+  let total = Math.floor(Number(patientCount));
+  if (!Number.isFinite(total) || total <= 0){
+    const cap = Math.floor(Number(zoneCapacity));
+    if (cap > 0){
+      total = Math.round(cap * (0.8 + Math.random() * 0.4));
+    } else {
+      total = Math.floor(Math.random() * 21) + 10; // between 10 and 30
+    }
+  }
+  const probs = [0.05, 0.15, 0.4, 0.3, 0.1];
+  const counts = probs.map(()=>0);
+  for (let i=0; i<total; i++){
+    const r = Math.random();
+    let acc = 0;
+    for (let j=0; j<probs.length; j++){
+      acc += probs[j];
+      if (r < acc){
+        counts[j]++;
+        break;
+      }
+    }
+  }
+  return { total, counts };
+}
+
+export { simulateEsiCounts };

--- a/tests/simulation.test.js
+++ b/tests/simulation.test.js
@@ -1,0 +1,16 @@
+const { simulateEsiCounts } = require('../simulation');
+
+describe('simulateEsiCounts', () => {
+  test('generates patient count between 10 and 30 when none provided', () => {
+    const { total, counts } = simulateEsiCounts(0, 0);
+    expect(total).toBeGreaterThanOrEqual(10);
+    expect(total).toBeLessThanOrEqual(30);
+    expect(counts.reduce((a, b) => a + b, 0)).toBe(total);
+  });
+
+  test('respects specified patient count', () => {
+    const { total, counts } = simulateEsiCounts(15, 100);
+    expect(total).toBe(15);
+    expect(counts.reduce((a, b) => a + b, 0)).toBe(15);
+  });
+});

--- a/ui.js
+++ b/ui.js
@@ -3,6 +3,7 @@ import { initZones } from './zones.js';
 import { downloadCsv, downloadPdf } from './downloads.js';
 import { compute as coreCompute } from './compute.js';
 import { updateChart } from './chart-utils.js';
+import { simulateEsiCounts } from './simulation.js';
 
 const LS_RATE_KEY = 'ED_RATE_TEMPLATE_V2';
 
@@ -314,21 +315,10 @@ function compute(){
 }
 
 function simulateEsi(){
-  let total = Math.floor(toNum(els.patientCount.value));
-  if (total <= 0) {
-    const cap = Math.floor(toNum(els.zoneCapacity.value));
-    total = cap > 0 ? Math.round(cap * (0.8 + Math.random() * 0.4)) : Math.round(20 + Math.random() * 80);
-  }
-  const probs = [0.05, 0.15, 0.4, 0.3, 0.1];
-  const counts = [0, 0, 0, 0, 0];
-  for (let i = 0; i < total; i++) {
-    const r = Math.random();
-    let acc = 0;
-    for (let j = 0; j < probs.length; j++) {
-      acc += probs[j];
-      if (r < acc) { counts[j]++; break; }
-    }
-  }
+  const { total, counts } = simulateEsiCounts(
+    toNum(els.patientCount.value),
+    toNum(els.zoneCapacity.value)
+  );
   [els.esi1.value, els.esi2.value, els.esi3.value, els.esi4.value, els.esi5.value] = counts;
   if (!els.linkPatientCount.checked) {
     els.patientCount.value = total;


### PR DESCRIPTION
## Summary
- extract patient distribution logic into `simulateEsiCounts`
- randomize default patient total between 10 and 30 when unspecified
- update UI to use new simulation helper and add tests for it

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b95664105483209a1704381f38251a