### PR TITLE
Refresh patient count on each simulation

### DIFF
--- a/ui.js
+++ b/ui.js
@@ -315,8 +315,9 @@ function compute(){
 }
 
 function simulateEsi(){
+  const patientCount = els.linkPatientCount.checked ? 0 : toNum(els.patientCount.value);
   const { total, counts } = simulateEsiCounts(
-    toNum(els.patientCount.value),
+    patientCount,
     toNum(els.zoneCapacity.value)
   );
   [els.esi1.value, els.esi2.value, els.esi3.value, els.esi4.value, els.esi5.value] = counts;


### PR DESCRIPTION
## Summary
- ensure each simulate click ignores previous patient count when linked to ESI counts

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b9577e97b083209554f05d633769b3