### PR TITLE
Simplify default zones

### DIFF
--- a/index.html
+++ b/index.html
@@ -243,7 +243,7 @@
         </thead>
         <tbody id="zoneTbody"></tbody>
       </table>
-      <div class="help small">Pastaba: <strong>Kodas</strong> turi būti unikalus (pvz., RED, YEL, GRN). Grupę galite įvesti savo (pvz., „Suaugusiųjų“, „Vaikų“).</div>
+      <div class="help small">Pastaba: <strong>Kodas</strong> turi būti unikalus (pvz., A, B, FAST). Grupę galite įvesti savo (pvz., „Suaugusiųjų“, „Vaikų“).</div>
     </div>
   </div>
     <!-- Chart.js v4.4.9 pinned to avoid unexpected breaking changes -->

--- a/tests/csv.test.js
+++ b/tests/csv.test.js
@@ -36,8 +36,8 @@ test('handles commas in zone_label', () => {
   const data = {
     date: '2024-01-01',
     shift: 'D',
-    zone: 'RED',
-    zone_label: 'Critical, Red Zone',
+    zone: 'A',
+    zone_label: 'Zona A, test zone',
     zoneCapacity: 20,
     patientCount: 10,
     ESI: { n1: 1, n2: 2, n3: 3, n4: 4, n5: 0 },

--- a/zones.js
+++ b/zones.js
@@ -1,10 +1,8 @@
 export const DEFAULT_ZONES = [
-  { id: 'RED',   name: 'Raudona (kritinė)',       group: 'Suaugusiųjų', cap: { D: 16, N: 12, P: 28 } },
-  { id: 'YEL',   name: 'Geltona (vidutinė)',      group: 'Suaugusiųjų', cap: { D: 22, N: 15, P: 37 } },
-  { id: 'GRN',   name: 'Žalia (mažesnė skuba)',   group: 'Suaugusiųjų', cap: { D: 28, N: 20, P: 48 } },
-  { id: 'TRIAGE',name: 'Triage/registracija',     group: 'Bendra',       cap: { D: 35, N: 24, P: 59 } },
-  { id: 'OBS',   name: 'Stebėjimo zona',          group: 'Bendra',       cap: { D: 14, N: 10, P: 24 } },
-  { id: 'OTHER', name: 'Kita',                    group: 'Bendra',       cap: { D: 20, N: 16, P: 36 } }
+  { id: 'A',    name: 'A',           group: 'Suaugusiųjų', cap: { D: 16, N: 12, P: 28 } },
+  { id: 'B',    name: 'B',           group: 'Suaugusiųjų', cap: { D: 22, N: 15, P: 37 } },
+  { id: 'FAST', name: 'Fasttrack',   group: 'Suaugusiųjų', cap: { D: 28, N: 20, P: 48 } },
+  { id: 'OBS',  name: 'Stebėjimo zona', group: 'Bendra', cap: { D: 14, N: 10, P: 24 } }
 ];
 
 const LS_KEY = 'ED_ZONES_V2';


### PR DESCRIPTION
## Summary
- replace default zones with A, B, Fasttrack and Stebėjimo
- adjust CSV tests and UI help text for new zone codes

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b958f8adf483209d5890b43398ba6d