### PR TITLE
Shift KPI charts to left column

### DIFF
--- a/index.html
+++ b/index.html
@@ -148,13 +148,13 @@
       <div class="card">
         <h2>Rezultatai</h2>
         <div class="kpi">
-          <div class="item">
+          <div class="item ratio-item">
             <div class="label">Santykis Pacientų skaičius/Zonos talpa</div>
             <div class="val" id="ratio">0.00</div>
             <canvas id="ratioChart" width="480" height="240"></canvas>
             <div class="help">Apkrovos intervalas lemia V<sub>priedas</sub></div>
           </div>
-          <div class="item">
+          <div class="item s-item">
             <div class="label">Aukštos skubos dalis S = (ESI1+ESI2)/Pacientų skaičius</div>
             <div class="val" id="sShare">0.00</div>
             <canvas id="sChart" width="480" height="240"></canvas>

--- a/styles.css
+++ b/styles.css
@@ -90,14 +90,18 @@
     .switch-block { margin: 10px 0 6px; }
 
     .kpi { display: grid; gap: 12px; margin-top: 8px; }
-    @media (min-width: 960px) { .kpi { grid-template-columns: repeat(3, minmax(0,1fr)); } }
+    @media (min-width: 960px) {
+      .kpi { grid-template-columns: 1fr 1fr; }
+      .kpi .ratio-item { grid-column: 1; grid-row: 1; }
+      .kpi .s-item { grid-column: 1; grid-row: 2; }
+      .kpi .pay-chart { grid-column: 2; grid-row: 1 / span 2; }
+    }
     .role-heading { margin-top: 14px; }
     .kpi .item { padding: 12px; border-radius: 14px; border: 1px solid var(--border); background: var(--panel); }
     .kpi .label { font-size: var(--font-xs); color: var(--muted); }
     .kpi .val { font-size: var(--font-lg); font-weight: 700; margin-top: 2px; }
     .kpi canvas { width: 100%; max-width: 120px; height: 60px !important; margin-top: 8px; }
     .kpi .pay-chart canvas { max-width: none; height: 240px !important; }
-    @media (min-width: 960px) { .kpi .pay-chart { grid-column: 1 / -1; } }
     .pill { display:inline-block; padding: 4px 8px; border-radius: 999px; font-size: var(--font-xs); border:1px solid var(--border); background:var(--panel); }
     .accent { color: var(--accent); }
     .muted { color: var(--muted); }


### PR DESCRIPTION
## Summary
- Stack patient-to-capacity ratio and high-urgency share charts in the KPI left column
- Adjust KPI grid to two columns with pay chart spanning the right side

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b9672a03b08320987f516f34f99610