### PR TITLE
Add period simulation and patient flow visualization

### DIFF
--- a/chart-utils.js
+++ b/chart-utils.js
@@ -3,7 +3,31 @@ export function updateChart(chart, updater) {
   updater(chart);
 }
 
+export function createFlowChart(canvas, color = '#007bff') {
+  if (!canvas || typeof Chart === 'undefined') return null;
+  const ctx = canvas.getContext && canvas.getContext('2d');
+  if (!ctx) return null;
+  return new Chart(ctx, {
+    type: 'line',
+    data: { labels: [], datasets: [{ label: 'Pacientų srautas laike', data: [], borderColor: color, backgroundColor: 'transparent', tension: 0.3 }] },
+    options: {
+      plugins: { legend: { display: false } },
+      scales: { x: { title: { display: true, text: 'Diena' } }, y: { beginAtZero: true } },
+      maintainAspectRatio: false,
+      responsive: true,
+    }
+  });
+}
+
+export function updateFlowChart(chart, results) {
+  updateChart(chart, c => {
+    c.data.labels = results.map(r => r.day);
+    c.data.datasets[0].data = results.map(r => r.total);
+    c.update();
+  });
+}
+
 // CommonJS support for tests
 if (typeof module !== 'undefined') {
-  module.exports = { updateChart };
+  module.exports = { updateChart, createFlowChart, updateFlowChart };
 }

--- a/index.html
+++ b/index.html
@@ -133,8 +133,19 @@
             <label>&nbsp;</label>
             <div class="help">Jei nėra triažo – palikite visur nulį.</div>
           </div>
-        </div>
+          </div>
 
+
+        <div class="row">
+          <div>
+            <label for="days">Dienų skaičius</label>
+            <input id="days" type="number" min="1" step="1" value="7" />
+          </div>
+          <div>
+            <label>&nbsp;</label>
+            <button id="simulatePeriod">Simuliuoti periodą</button>
+          </div>
+        </div>
 
           <div class="actions">
             <button id="simulateEsi">Simuliuoti pamainą</button>
@@ -160,11 +171,15 @@
             <canvas id="sChart" width="480" height="240"></canvas>
             <div class="help">Lemia A<sub>priedas</sub></div>
           </div>
-          <div class="item pay-chart">
-            <div class="label">Tarifų grafikas</div>
-            <canvas id="payChart" width="480" height="160"></canvas>
+            <div class="item pay-chart">
+              <div class="label">Tarifų grafikas</div>
+              <canvas id="payChart" width="480" height="160"></canvas>
+            </div>
+            <div class="item">
+              <div class="label">Pacientų srautas laike</div>
+              <canvas id="flowChart" width="480" height="240"></canvas>
+            </div>
           </div>
-        </div>
 
         <table class="table">
           <thead>

--- a/simulation.js
+++ b/simulation.js
@@ -24,4 +24,15 @@ function simulateEsiCounts(patientCount, zoneCapacity){
   return { total, counts };
 }
 
-export { simulateEsiCounts };
+function simulatePeriod(days, zoneCapacity){
+  const d = Math.max(0, Math.floor(Number(days)));
+  const cap = Number(zoneCapacity);
+  const results = [];
+  for (let i=0; i<d; i++){
+    const { total, counts } = simulateEsiCounts(0, cap);
+    results.push({ day: i + 1, total, counts });
+  }
+  return results;
+}
+
+export { simulateEsiCounts, simulatePeriod };

--- a/tests/chart-utils.test.js
+++ b/tests/chart-utils.test.js
@@ -1,4 +1,4 @@
-import { updateChart } from '../chart-utils.js';
+import { updateChart, createFlowChart, updateFlowChart } from '../chart-utils.js';
 
 describe('updateChart', () => {
   test('calls updater when chart is valid', () => {
@@ -20,5 +20,32 @@ describe('updateChart', () => {
     const updater = jest.fn();
     updateChart(chart, updater);
     expect(updater).not.toHaveBeenCalled();
+  });
+});
+
+describe('createFlowChart', () => {
+  test('returns null without canvas', () => {
+    expect(createFlowChart(null)).toBeNull();
+  });
+
+  test('creates chart when Chart is available', () => {
+    const ctx = {};
+    const canvas = { getContext: jest.fn(() => ctx) };
+    global.Chart = jest.fn(() => ({ data: { labels: [], datasets: [{ data: [] }] }, update: jest.fn() }));
+    const chart = createFlowChart(canvas, '#000');
+    expect(canvas.getContext).toHaveBeenCalledWith('2d');
+    expect(global.Chart).toHaveBeenCalled();
+    expect(chart).toBeTruthy();
+    delete global.Chart;
+  });
+});
+
+describe('updateFlowChart', () => {
+  test('updates chart data and calls update', () => {
+    const chart = { data: { labels: [], datasets: [{ data: [] }] }, update: jest.fn() };
+    updateFlowChart(chart, [ { day: 1, total: 5 }, { day: 2, total: 10 } ]);
+    expect(chart.data.labels).toEqual([1,2]);
+    expect(chart.data.datasets[0].data).toEqual([5,10]);
+    expect(chart.update).toHaveBeenCalled();
   });
 });

--- a/tests/simulation.test.js
+++ b/tests/simulation.test.js
@@ -1,4 +1,4 @@
-const { simulateEsiCounts } = require('../simulation');
+const { simulateEsiCounts, simulatePeriod } = require('../simulation');
 
 describe('simulateEsiCounts', () => {
   test('generates patient count between 10 and 30 when none provided', () => {
@@ -12,5 +12,20 @@ describe('simulateEsiCounts', () => {
     const { total, counts } = simulateEsiCounts(15, 100);
     expect(total).toBe(15);
     expect(counts.reduce((a, b) => a + b, 0)).toBe(15);
+  });
+});
+
+describe('simulatePeriod', () => {
+  test('returns array with given number of days', () => {
+    const res = simulatePeriod(5, 0);
+    expect(res).toHaveLength(5);
+  });
+
+  test('uses zone capacity when provided', () => {
+    const orig = Math.random;
+    Math.random = () => 0; // deterministic
+    const res = simulatePeriod(1, 100);
+    Math.random = orig;
+    expect(res[0].total).toBe(80);
   });
 });


### PR DESCRIPTION
## Summary
- add `simulatePeriod` for multi-day patient count simulation
- extend UI with day count input, period simulation button, and flow chart
- provide chart utilities to create and update "Pacientų srautas laike" line chart

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b982a96da48320ae046661c9018146