### PR TITLE
Align day simulation with real patient averages

### DIFF
--- a/simulation.js
+++ b/simulation.js
@@ -24,15 +24,18 @@ function simulateEsiCounts(patientCount, zoneCapacity){
   return { total, counts };
 }
 
+const DAILY_PATIENT_COUNTS = [135, 126, 124, 122, 130, 117, 119];
+
 function simulatePeriod(days, zoneCapacity){
   const d = Math.max(0, Math.floor(Number(days)));
   const cap = Number(zoneCapacity);
   const results = [];
   for (let i=0; i<d; i++){
-    const { total, counts } = simulateEsiCounts(0, cap);
+    const dayTotal = DAILY_PATIENT_COUNTS[i % DAILY_PATIENT_COUNTS.length];
+    const { total, counts } = simulateEsiCounts(dayTotal, cap);
     results.push({ day: i + 1, total, counts });
   }
   return results;
 }
 
-export { simulateEsiCounts, simulatePeriod };
+export { simulateEsiCounts, simulatePeriod, DAILY_PATIENT_COUNTS };

--- a/tests/simulation.test.js
+++ b/tests/simulation.test.js
@@ -20,12 +20,10 @@ describe('simulatePeriod', () => {
     const res = simulatePeriod(5, 0);
     expect(res).toHaveLength(5);
   });
-
-  test('uses zone capacity when provided', () => {
-    const orig = Math.random;
-    Math.random = () => 0; // deterministic
-    const res = simulatePeriod(1, 100);
-    Math.random = orig;
-    expect(res[0].total).toBe(80);
+  
+  test('follows real daily patient counts pattern', () => {
+    const res = simulatePeriod(7, 0);
+    const totals = res.map(r => r.total);
+    expect(totals).toEqual([135, 126, 124, 122, 130, 117, 119]);
   });
 });


### PR DESCRIPTION
## Summary
- Generate daily patient totals based on real average counts
- Update simulation tests for new day-of-week pattern

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b98595b98c8320adbb15c66533437e