### PR TITLE
Add configurable options to simulatePeriod

### DIFF
--- a/simulation.js
+++ b/simulation.js
@@ -26,12 +26,19 @@ function simulateEsiCounts(patientCount, zoneCapacity){
 
 const DAILY_PATIENT_COUNTS = [135, 126, 124, 122, 130, 117, 119];
 
-function simulatePeriod(days, zoneCapacity){
+function simulatePeriod(days, zoneCapacity, options = {}){
+  const {
+    patientCounts = DAILY_PATIENT_COUNTS,
+    variation = 0,
+    startIndex = 0
+  } = options;
   const d = Math.max(0, Math.floor(Number(days)));
   const cap = Number(zoneCapacity);
   const results = [];
-  for (let i=0; i<d; i++){
-    const dayTotal = DAILY_PATIENT_COUNTS[i % DAILY_PATIENT_COUNTS.length];
+  for (let i = 0; i < d; i++){
+    const base = patientCounts[(startIndex + i) % patientCounts.length];
+    const factor = 1 + (Math.random() * 2 - 1) * variation;
+    const dayTotal = base * factor;
     const { total, counts } = simulateEsiCounts(dayTotal, cap);
     results.push({ day: i + 1, total, counts });
   }

--- a/tests/simulation.test.js
+++ b/tests/simulation.test.js
@@ -26,4 +26,18 @@ describe('simulatePeriod', () => {
     const totals = res.map(r => r.total);
     expect(totals).toEqual([135, 126, 124, 122, 130, 117, 119]);
   });
+
+  test('uses custom patientCounts and startIndex', () => {
+    const res = simulatePeriod(4, 0, { patientCounts: [10, 20], startIndex: 1 });
+    const totals = res.map(r => r.total);
+    expect(totals).toEqual([20, 10, 20, 10]);
+  });
+
+  test('applies variation within expected bounds', () => {
+    const res = simulatePeriod(5, 0, { patientCounts: [100], variation: 0.1 });
+    res.forEach(r => {
+      expect(r.total).toBeGreaterThanOrEqual(90);
+      expect(r.total).toBeLessThan(110);
+    });
+  });
 });

--- a/ui.js
+++ b/ui.js
@@ -345,7 +345,7 @@ function simulateEsi(){
 function simulatePeriodUi(){
   const days = toNum(els.days.value);
   const zoneCapacity = toNum(els.zoneCapacity.value);
-  const results = simulatePeriodSim(days, zoneCapacity);
+  const results = simulatePeriodSim(days, zoneCapacity, {});
   updateFlowChart(charts.flow, results);
 }
 


### PR DESCRIPTION
## Summary
- Extend `simulatePeriod` to accept an `options` object (patientCounts, variation, startIndex)
- Apply optional variation and flexible patient count patterns
- Update UI to call `simulatePeriod` with new signature
- Add tests for custom patient counts and variation

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b991447e888320be208f28a6adb2ee