### PR TITLE
Add summary aggregation to simulatePeriod output

### DIFF
--- a/chart-utils.js
+++ b/chart-utils.js
@@ -20,9 +20,10 @@ export function createFlowChart(canvas, color = '#007bff') {
 }
 
 export function updateFlowChart(chart, results) {
+  const days = Array.isArray(results) ? results : (results && results.days) || [];
   updateChart(chart, c => {
-    c.data.labels = results.map(r => r.day);
-    c.data.datasets[0].data = results.map(r => r.total);
+    c.data.labels = days.map(r => r.day);
+    c.data.datasets[0].data = days.map(r => r.total);
     c.update();
   });
 }

--- a/simulation.js
+++ b/simulation.js
@@ -35,14 +35,19 @@ function simulatePeriod(days, zoneCapacity, options = {}){
   const d = Math.max(0, Math.floor(Number(days)));
   const cap = Number(zoneCapacity);
   const results = [];
+  const summary = { totalPatients: 0, esiTotals: [0,0,0,0,0] };
   for (let i = 0; i < d; i++){
     const base = patientCounts[(startIndex + i) % patientCounts.length];
     const factor = 1 + (Math.random() * 2 - 1) * variation;
     const dayTotal = base * factor;
     const { total, counts } = simulateEsiCounts(dayTotal, cap);
     results.push({ day: i + 1, total, counts });
+    summary.totalPatients += total;
+    for (let j = 0; j < counts.length; j++){
+      summary.esiTotals[j] += counts[j];
+    }
   }
-  return results;
+  return { days: results, summary };
 }
 
 export { simulateEsiCounts, simulatePeriod, DAILY_PATIENT_COUNTS };

--- a/tests/simulation.test.js
+++ b/tests/simulation.test.js
@@ -18,26 +18,34 @@ describe('simulateEsiCounts', () => {
 describe('simulatePeriod', () => {
   test('returns array with given number of days', () => {
     const res = simulatePeriod(5, 0);
-    expect(res).toHaveLength(5);
+    expect(res.days).toHaveLength(5);
   });
-  
+
   test('follows real daily patient counts pattern', () => {
     const res = simulatePeriod(7, 0);
-    const totals = res.map(r => r.total);
+    const totals = res.days.map(r => r.total);
     expect(totals).toEqual([135, 126, 124, 122, 130, 117, 119]);
   });
 
   test('uses custom patientCounts and startIndex', () => {
     const res = simulatePeriod(4, 0, { patientCounts: [10, 20], startIndex: 1 });
-    const totals = res.map(r => r.total);
+    const totals = res.days.map(r => r.total);
     expect(totals).toEqual([20, 10, 20, 10]);
   });
 
   test('applies variation within expected bounds', () => {
     const res = simulatePeriod(5, 0, { patientCounts: [100], variation: 0.1 });
-    res.forEach(r => {
+    res.days.forEach(r => {
       expect(r.total).toBeGreaterThanOrEqual(90);
       expect(r.total).toBeLessThan(110);
     });
+  });
+
+  test('aggregates summary totals correctly', () => {
+    const res = simulatePeriod(2, 0, { patientCounts: [10], variation: 0 });
+    const sumTotals = res.days.reduce((acc, d) => acc + d.total, 0);
+    const sumCounts = res.days.reduce((acc, d) => acc.map((v, i) => v + d.counts[i]), [0,0,0,0,0]);
+    expect(res.summary.totalPatients).toBe(sumTotals);
+    expect(res.summary.esiTotals).toEqual(sumCounts);
   });
 });


### PR DESCRIPTION
## Summary
- extend `simulatePeriod` to return daily results alongside an aggregated summary of total patients and ESI counts
- make `updateFlowChart` compatible with the new `{days, summary}` structure while supporting legacy arrays
- adjust simulation tests for new return format and verify summary aggregation

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b99234da18832089a86c8b611f9231