### PR TITLE
Add optional seed for deterministic simulation

### DIFF
--- a/simulation.js
+++ b/simulation.js
@@ -1,21 +1,30 @@
-function simulateEsiCounts(patientCount, zoneCapacity){
+function createRng(seed) {
+  let state = Number(seed) >>> 0;
+  return function () {
+    state = (1664525 * state + 1013904223) >>> 0;
+    return state / 4294967296;
+  };
+}
+
+function simulateEsiCounts(patientCount, zoneCapacity, seed) {
+  const rng = typeof seed === 'function' ? seed : seed !== undefined ? createRng(seed) : Math.random;
   let total = Math.floor(Number(patientCount));
-  if (!Number.isFinite(total) || total <= 0){
+  if (!Number.isFinite(total) || total <= 0) {
     const cap = Math.floor(Number(zoneCapacity));
-    if (cap > 0){
-      total = Math.round(cap * (0.8 + Math.random() * 0.4));
+    if (cap > 0) {
+      total = Math.round(cap * (0.8 + rng() * 0.4));
     } else {
-      total = Math.floor(Math.random() * 21) + 10; // between 10 and 30
+      total = Math.floor(rng() * 21) + 10; // between 10 and 30
     }
   }
   const probs = [0.05, 0.15, 0.4, 0.3, 0.1];
-  const counts = probs.map(()=>0);
-  for (let i=0; i<total; i++){
-    const r = Math.random();
+  const counts = probs.map(() => 0);
+  for (let i = 0; i < total; i++) {
+    const r = rng();
     let acc = 0;
-    for (let j=0; j<probs.length; j++){
+    for (let j = 0; j < probs.length; j++) {
       acc += probs[j];
-      if (r < acc){
+      if (r < acc) {
         counts[j]++;
         break;
       }
@@ -26,24 +35,25 @@ function simulateEsiCounts(patientCount, zoneCapacity){
 
 const DAILY_PATIENT_COUNTS = [135, 126, 124, 122, 130, 117, 119];
 
-function simulatePeriod(days, zoneCapacity, options = {}){
+function simulatePeriod(days, zoneCapacity, options = {}, seed) {
   const {
     patientCounts = DAILY_PATIENT_COUNTS,
     variation = 0,
     startIndex = 0
   } = options;
+  const rng = typeof seed === 'function' ? seed : seed !== undefined ? createRng(seed) : Math.random;
   const d = Math.max(0, Math.floor(Number(days)));
   const cap = Number(zoneCapacity);
   const results = [];
-  const summary = { totalPatients: 0, esiTotals: [0,0,0,0,0] };
-  for (let i = 0; i < d; i++){
+  const summary = { totalPatients: 0, esiTotals: [0, 0, 0, 0, 0] };
+  for (let i = 0; i < d; i++) {
     const base = patientCounts[(startIndex + i) % patientCounts.length];
-    const factor = 1 + (Math.random() * 2 - 1) * variation;
+    const factor = 1 + (rng() * 2 - 1) * variation;
     const dayTotal = base * factor;
-    const { total, counts } = simulateEsiCounts(dayTotal, cap);
+    const { total, counts } = simulateEsiCounts(dayTotal, cap, rng);
     results.push({ day: i + 1, total, counts });
     summary.totalPatients += total;
-    for (let j = 0; j < counts.length; j++){
+    for (let j = 0; j < counts.length; j++) {
       summary.esiTotals[j] += counts[j];
     }
   }

--- a/tests/simulation.test.js
+++ b/tests/simulation.test.js
@@ -13,6 +13,13 @@ describe('simulateEsiCounts', () => {
     expect(total).toBe(15);
     expect(counts.reduce((a, b) => a + b, 0)).toBe(15);
   });
+
+  test('produces consistent results with seed', () => {
+    const seed = 123;
+    const res1 = simulateEsiCounts(0, 0, seed);
+    const res2 = simulateEsiCounts(0, 0, seed);
+    expect(res1).toEqual(res2);
+  });
 });
 
 describe('simulatePeriod', () => {
@@ -47,5 +54,13 @@ describe('simulatePeriod', () => {
     const sumCounts = res.days.reduce((acc, d) => acc.map((v, i) => v + d.counts[i]), [0,0,0,0,0]);
     expect(res.summary.totalPatients).toBe(sumTotals);
     expect(res.summary.esiTotals).toEqual(sumCounts);
+  });
+
+  test('produces consistent results with seed', () => {
+    const seed = 456;
+    const opts = { patientCounts: [100], variation: 0.2 };
+    const res1 = simulatePeriod(3, 0, opts, seed);
+    const res2 = simulatePeriod(3, 0, opts, seed);
+    expect(res1).toEqual(res2);
   });
 });


### PR DESCRIPTION
## Summary
- Allow `simulateEsiCounts` and `simulatePeriod` to accept an optional seed
- Use a simple LCG-based generator when seeded to produce deterministic output
- Add tests verifying consistency when a seed is supplied

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b99a64da108320a52dc23bfb3908b7