### PR TITLE
Add budget computation module

### DIFF
--- a/budget.js
+++ b/budget.js
@@ -1,0 +1,41 @@
+function sanitizeCount(value) {
+  return Number.isFinite(value) ? Math.max(0, value) : 0;
+}
+
+import { compute } from './compute';
+
+export function computeBudget({ counts = {}, rateInputs = {} }) {
+  const salaryData = compute(rateInputs);
+  const roles = ['doctor', 'nurse', 'assistant'];
+
+  const cleanCounts = {};
+  const shift_budget = {};
+  const month_budget = {};
+  let shift_total = 0;
+  let month_total = 0;
+
+  for (const role of roles) {
+    const count = sanitizeCount(counts[role]);
+    cleanCounts[role] = count;
+    const shift = (salaryData.shift_salary?.[role] || 0) * count;
+    const month = (salaryData.month_salary?.[role] || 0) * count;
+    shift_budget[role] = shift;
+    month_budget[role] = month;
+    shift_total += shift;
+    month_total += month;
+  }
+
+  shift_budget.total = shift_total;
+  month_budget.total = month_total;
+
+  return {
+    ...salaryData,
+    counts: cleanCounts,
+    shift_budget,
+    month_budget,
+  };
+}
+
+if (typeof module !== 'undefined') {
+  module.exports = { computeBudget };
+}

--- a/tests/budget.test.js
+++ b/tests/budget.test.js
@@ -1,0 +1,56 @@
+const { computeBudget } = require('../budget');
+
+describe('computeBudget', () => {
+  test('calculates per-role and total budgets', () => {
+    const result = computeBudget({
+      counts: { doctor: 2, nurse: 3, assistant: 1 },
+      rateInputs: {
+        zoneCapacity: 100,
+        patientCount: 0,
+        maxCoefficient: 1.3,
+        baseDoc: 10,
+        baseNurse: 8,
+        baseAssist: 6,
+        shiftH: 12,
+        monthH: 160,
+        n1: 0,
+        n2: 0,
+        n3: 0,
+        n4: 0,
+        n5: 0,
+      },
+    });
+
+    expect(result.shift_budget.doctor).toBeCloseTo(240);
+    expect(result.shift_budget.nurse).toBeCloseTo(288);
+    expect(result.shift_budget.assistant).toBeCloseTo(72);
+    expect(result.shift_budget.total).toBeCloseTo(600);
+    expect(result.month_budget.total).toBeCloseTo(8000);
+  });
+
+  test('handles invalid counts', () => {
+    const result = computeBudget({
+      counts: { doctor: NaN, nurse: -1, assistant: 1 },
+      rateInputs: {
+        zoneCapacity: 100,
+        patientCount: 0,
+        maxCoefficient: 1.3,
+        baseDoc: 10,
+        baseNurse: 8,
+        baseAssist: 6,
+        shiftH: 12,
+        monthH: 160,
+        n1: 0,
+        n2: 0,
+        n3: 0,
+        n4: 0,
+        n5: 0,
+      },
+    });
+
+    expect(result.shift_budget.doctor).toBe(0);
+    expect(result.shift_budget.nurse).toBe(0);
+    expect(result.shift_budget.assistant).toBeCloseTo(72);
+    expect(result.shift_budget.total).toBeCloseTo(72);
+  });
+});


### PR DESCRIPTION
## Summary
- add `computeBudget` helper to calculate shift and monthly budget totals from staff counts and rate inputs
- cover budget calculations with unit tests

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b99f702c048320a3fd2b6b1a8474a0