### PR TITLE
Add budget planner interface

### DIFF
--- a/budget-ui.js
+++ b/budget-ui.js
@@ -1,0 +1,88 @@
+import { initThemeToggle } from './theme.js';
+import { computeBudget } from './budget.js';
+
+function toNum(v){ const n = Number(v); return Number.isFinite(n) ? n : 0; }
+function money(n){ try{ return new Intl.NumberFormat('lt-LT',{style:'currency',currency:'EUR'}).format(n||0); }catch{ return `€${(n||0).toFixed(2)}`; } }
+
+const els = {
+  shiftHours: document.getElementById('shiftHours'),
+  monthHours: document.getElementById('monthHours'),
+  baseRateDoc: document.getElementById('baseRateDoc'),
+  baseRateNurse: document.getElementById('baseRateNurse'),
+  baseRateAssist: document.getElementById('baseRateAssist'),
+  countDoc: document.getElementById('countDoc'),
+  countNurse: document.getElementById('countNurse'),
+  countAssist: document.getElementById('countAssist'),
+  countDocCell: document.getElementById('countDocCell'),
+  countNurseCell: document.getElementById('countNurseCell'),
+  countAssistCell: document.getElementById('countAssistCell'),
+  rateDocCell: document.getElementById('rateDocCell'),
+  rateNurseCell: document.getElementById('rateNurseCell'),
+  rateAssistCell: document.getElementById('rateAssistCell'),
+  shiftDocCell: document.getElementById('shiftDocCell'),
+  shiftNurseCell: document.getElementById('shiftNurseCell'),
+  shiftAssistCell: document.getElementById('shiftAssistCell'),
+  monthDocCell: document.getElementById('monthDocCell'),
+  monthNurseCell: document.getElementById('monthNurseCell'),
+  monthAssistCell: document.getElementById('monthAssistCell'),
+  shiftTotalCell: document.getElementById('shiftTotalCell'),
+  monthTotalCell: document.getElementById('monthTotalCell'),
+};
+
+initThemeToggle();
+
+function compute(){
+  const data = computeBudget({
+    counts: {
+      doctor: toNum(els.countDoc.value),
+      nurse: toNum(els.countNurse.value),
+      assistant: toNum(els.countAssist.value),
+    },
+    rateInputs: {
+      zoneCapacity: 1,
+      patientCount: 0,
+      maxCoefficient: 1,
+      baseDoc: toNum(els.baseRateDoc.value),
+      baseNurse: toNum(els.baseRateNurse.value),
+      baseAssist: toNum(els.baseRateAssist.value),
+      shiftH: toNum(els.shiftHours.value),
+      monthH: toNum(els.monthHours.value),
+      n1: 0,
+      n2: 0,
+      n3: 0,
+      n4: 0,
+      n5: 0,
+    }
+  });
+
+  els.countDocCell.textContent = data.counts.doctor;
+  els.countNurseCell.textContent = data.counts.nurse;
+  els.countAssistCell.textContent = data.counts.assistant;
+
+  els.rateDocCell.textContent = money(data.final_rates.doctor);
+  els.rateNurseCell.textContent = money(data.final_rates.nurse);
+  els.rateAssistCell.textContent = money(data.final_rates.assistant);
+
+  els.shiftDocCell.textContent = money(data.shift_budget.doctor);
+  els.shiftNurseCell.textContent = money(data.shift_budget.nurse);
+  els.shiftAssistCell.textContent = money(data.shift_budget.assistant);
+  els.shiftTotalCell.textContent = money(data.shift_budget.total);
+
+  els.monthDocCell.textContent = money(data.month_budget.doctor);
+  els.monthNurseCell.textContent = money(data.month_budget.nurse);
+  els.monthAssistCell.textContent = money(data.month_budget.assistant);
+  els.monthTotalCell.textContent = money(data.month_budget.total);
+}
+
+['input','change'].forEach(evt => {
+  ['shiftHours','monthHours','baseRateDoc','baseRateNurse','baseRateAssist','countDoc','countNurse','countAssist'].forEach(id => {
+    const el = els[id];
+    if (el) el.addEventListener(evt, compute);
+  });
+});
+
+compute();
+
+if (typeof module !== 'undefined') {
+  module.exports = { compute };
+}

--- a/budget.html
+++ b/budget.html
@@ -1,0 +1,85 @@
+<!DOCTYPE html>
+<html lang="lt">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>Biudžeto Planavimo Skaičiuoklė</title>
+  <link rel="stylesheet" href="styles.css">
+</head>
+<body>
+  <div class="container">
+    <div class="title">
+      <h1>Biudžeto Planavimo Skaičiuoklė</h1>
+      <label class="switch">
+        <input id="themeToggle" type="checkbox" />
+        <span>Šviesi tema</span>
+      </label>
+    </div>
+
+    <div class="grid grid-2">
+      <div class="card">
+        <h2>Įvestis</h2>
+        <div class="row">
+          <div>
+            <label for="shiftHours">Pamainos trukmė (val.)</label>
+            <input id="shiftHours" type="number" min="0" step="0.5" value="12" />
+          </div>
+          <div>
+            <label for="monthHours">Mėnesio valandos</label>
+            <input id="monthHours" type="number" min="0" step="0.5" value="160" />
+          </div>
+        </div>
+        <div class="row">
+          <div>
+            <label for="baseRateDoc">Bazinis gydytojo tarifas (€ / val.)</label>
+            <input id="baseRateDoc" type="number" min="0" step="0.01" value="0" placeholder="pvz. 25.00" />
+          </div>
+          <div>
+            <label for="countDoc">Gydytojų skaičius</label>
+            <input id="countDoc" type="number" min="0" step="1" value="0" />
+          </div>
+        </div>
+        <div class="row">
+          <div>
+            <label for="baseRateNurse">Bazinis slaugytojo tarifas (€ / val.)</label>
+            <input id="baseRateNurse" type="number" min="0" step="0.01" value="0" placeholder="pvz. 14.00" />
+          </div>
+          <div>
+            <label for="countNurse">Slaugytojų skaičius</label>
+            <input id="countNurse" type="number" min="0" step="1" value="0" />
+          </div>
+        </div>
+        <div class="row">
+          <div>
+            <label for="baseRateAssist">Bazinis padėjėjo tarifas (€ / val.)</label>
+            <input id="baseRateAssist" type="number" min="0" step="0.01" value="0" placeholder="pvz. 9.00" />
+          </div>
+          <div>
+            <label for="countAssist">Padėjėjų skaičius</label>
+            <input id="countAssist" type="number" min="0" step="1" value="0" />
+          </div>
+        </div>
+        <div class="actions">
+          <a href="index.html">Grįžti</a>
+        </div>
+      </div>
+
+      <div class="card">
+        <h2>Rezultatai</h2>
+        <table class="table">
+          <thead>
+            <tr><th>Rolė</th><th>Kiekis</th><th>Tarifas (€/val.)</th><th>Pamainos biudžetas</th><th>Mėnesio biudžetas</th></tr>
+          </thead>
+          <tbody>
+            <tr><td>Gydytojas</td><td id="countDocCell">0</td><td id="rateDocCell">€0,00</td><td id="shiftDocCell">€0,00</td><td id="monthDocCell">€0,00</td></tr>
+            <tr><td>Slaugytojas</td><td id="countNurseCell">0</td><td id="rateNurseCell">€0,00</td><td id="shiftNurseCell">€0,00</td><td id="monthNurseCell">€0,00</td></tr>
+            <tr><td>Padėjėjas</td><td id="countAssistCell">0</td><td id="rateAssistCell">€0,00</td><td id="shiftAssistCell">€0,00</td><td id="monthAssistCell">€0,00</td></tr>
+            <tr><td class="accent">Iš viso</td><td></td><td></td><td class="accent" id="shiftTotalCell">€0,00</td><td class="accent" id="monthTotalCell">€0,00</td></tr>
+          </tbody>
+        </table>
+      </div>
+    </div>
+  </div>
+  <script type="module" src="budget-ui.js"></script>
+</body>
+</html>

--- a/index.html
+++ b/index.html
@@ -14,6 +14,7 @@
         <input id="themeToggle" type="checkbox" />
         <span>Šviesi tema</span>
       </label>
+      <button id="budgetPlanner" type="button">Biudžeto planuoklis</button>
     </div>
 
     <div class="grid grid-2">

--- a/ui.js
+++ b/ui.js
@@ -69,6 +69,7 @@ const els = {
   loadRateTemplate: document.getElementById('loadRateTemplate'),
   payCanvas: document.getElementById('payChart'),
   flowCanvas: document.getElementById('flowChart'),
+  budgetPlanner: document.getElementById('budgetPlanner'),
 };
 
 // Legacy aliases
@@ -418,6 +419,10 @@ els.closeZoneModal.addEventListener('click', closeZoneModal);
 
 els.saveRateTemplate.addEventListener('click', (e)=>{ e.preventDefault(); saveRateTemplate(); });
 els.loadRateTemplate.addEventListener('click', (e)=>{ e.preventDefault(); loadRateTemplate(); });
+
+if (els.budgetPlanner) {
+  els.budgetPlanner.addEventListener('click', (e)=>{ e.preventDefault(); window.location.href = 'budget.html'; });
+}
 
 renderZoneSelect(false);
 resetAll();


### PR DESCRIPTION
## Summary
- add budget planner page with inputs for role counts and base rates
- compute budgets in new budget-ui module
- link to planner from main calculator

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b9a065ace08320b4e77b2ce8fda615