### PR TITLE
Add budget chart utilities and integrate into budget planner

### DIFF
--- a/budget-ui.js
+++ b/budget-ui.js
@@ -1,5 +1,6 @@
 import { initThemeToggle } from './theme.js';
 import { computeBudget } from './budget.js';
+import { createBudgetChart, updateBudgetChart } from './chart-utils.js';
 
 function toNum(v){ const n = Number(v); return Number.isFinite(n) ? n : 0; }
 function money(n){ try{ return new Intl.NumberFormat('lt-LT',{style:'currency',currency:'EUR'}).format(n||0); }catch{ return `€${(n||0).toFixed(2)}`; } }
@@ -27,9 +28,12 @@ const els = {
   monthAssistCell: document.getElementById('monthAssistCell'),
   shiftTotalCell: document.getElementById('shiftTotalCell'),
   monthTotalCell: document.getElementById('monthTotalCell'),
+  budgetChart: document.getElementById('budgetChart'),
 };
 
 initThemeToggle();
+
+const budgetChart = createBudgetChart(els.budgetChart, 'doughnut');
 
 function compute(){
   const data = computeBudget({
@@ -72,6 +76,8 @@ function compute(){
   els.monthNurseCell.textContent = money(data.month_budget.nurse);
   els.monthAssistCell.textContent = money(data.month_budget.assistant);
   els.monthTotalCell.textContent = money(data.month_budget.total);
+
+  updateBudgetChart(budgetChart, data.month_budget);
 }
 
 ['input','change'].forEach(evt => {

--- a/budget.html
+++ b/budget.html
@@ -77,9 +77,16 @@
             <tr><td class="accent">Iš viso</td><td></td><td></td><td class="accent" id="shiftTotalCell">€0,00</td><td class="accent" id="monthTotalCell">€0,00</td></tr>
           </tbody>
         </table>
+        <div class="kpi">
+          <div class="item budget-chart">
+            <div class="label">Biudžeto grafikas</div>
+            <canvas id="budgetChart" width="480" height="240"></canvas>
+          </div>
+        </div>
       </div>
     </div>
   </div>
+  <script src="https://cdn.jsdelivr.net/npm/chart.js@4.4.9?v=4.4.9"></script>
   <script type="module" src="budget-ui.js"></script>
 </body>
 </html>

--- a/chart-utils.js
+++ b/chart-utils.js
@@ -28,7 +28,46 @@ export function updateFlowChart(chart, results) {
   });
 }
 
+export function createBudgetChart(canvas, type = 'bar') {
+  if (!canvas || typeof Chart === 'undefined') return null;
+  const ctx = canvas.getContext && canvas.getContext('2d');
+  if (!ctx) return null;
+  const colors = ['#007bff', '#28a745', '#ffc107'];
+  return new Chart(ctx, {
+    type,
+    data: {
+      labels: ['Gydytojas', 'Slaugytojas', 'Padėjėjas'],
+      datasets: [{
+        label: 'Biudžetas',
+        data: [0, 0, 0],
+        backgroundColor: colors,
+        borderColor: colors,
+      }]
+    },
+    options: {
+      plugins: { legend: { display: type !== 'bar' } },
+      scales: type === 'bar' ? { y: { beginAtZero: true } } : {},
+      maintainAspectRatio: false,
+      responsive: true,
+    }
+  });
+}
+
+export function updateBudgetChart(chart, budgets = {}) {
+  const roles = ['doctor', 'nurse', 'assistant'];
+  updateChart(chart, c => {
+    c.data.datasets[0].data = roles.map(r => Number(budgets[r]) || 0);
+    c.update();
+  });
+}
+
 // CommonJS support for tests
 if (typeof module !== 'undefined') {
-  module.exports = { updateChart, createFlowChart, updateFlowChart };
+  module.exports = {
+    updateChart,
+    createFlowChart,
+    updateFlowChart,
+    createBudgetChart,
+    updateBudgetChart,
+  };
 }

--- a/tests/chart-utils.test.js
+++ b/tests/chart-utils.test.js
@@ -1,4 +1,10 @@
-import { updateChart, createFlowChart, updateFlowChart } from '../chart-utils.js';
+import {
+  updateChart,
+  createFlowChart,
+  updateFlowChart,
+  createBudgetChart,
+  updateBudgetChart,
+} from '../chart-utils.js';
 
 describe('updateChart', () => {
   test('calls updater when chart is valid', () => {
@@ -46,6 +52,32 @@ describe('updateFlowChart', () => {
     updateFlowChart(chart, [ { day: 1, total: 5 }, { day: 2, total: 10 } ]);
     expect(chart.data.labels).toEqual([1,2]);
     expect(chart.data.datasets[0].data).toEqual([5,10]);
+    expect(chart.update).toHaveBeenCalled();
+  });
+});
+
+describe('createBudgetChart', () => {
+  test('returns null without canvas', () => {
+    expect(createBudgetChart(null)).toBeNull();
+  });
+
+  test('creates chart when Chart is available', () => {
+    const ctx = {};
+    const canvas = { getContext: jest.fn(() => ctx) };
+    global.Chart = jest.fn(() => ({ data: { labels: [], datasets: [{ data: [] }] }, update: jest.fn() }));
+    const chart = createBudgetChart(canvas, 'bar');
+    expect(canvas.getContext).toHaveBeenCalledWith('2d');
+    expect(global.Chart).toHaveBeenCalled();
+    expect(chart).toBeTruthy();
+    delete global.Chart;
+  });
+});
+
+describe('updateBudgetChart', () => {
+  test('updates chart data and calls update', () => {
+    const chart = { data: { datasets: [{ data: [] }] }, update: jest.fn() };
+    updateBudgetChart(chart, { doctor: 10, nurse: 20, assistant: 30 });
+    expect(chart.data.datasets[0].data).toEqual([10,20,30]);
     expect(chart.update).toHaveBeenCalled();
   });
 });


### PR DESCRIPTION
## Summary
- add reusable helpers to build and update budget charts
- show budget distribution per role on budget page
- cover budget chart helpers with unit tests

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b9a28b77cc83209abeba9a3e0dad5e