### PR TITLE
Fix budget calculator theme and add day/night staffing inputs

### DIFF
--- a/budget-ui.js
+++ b/budget-ui.js
@@ -3,7 +3,13 @@ import { computeBudget } from './budget.js';
 import { createBudgetChart, updateBudgetChart } from './chart-utils.js';
 
 function toNum(v){ const n = Number(v); return Number.isFinite(n) ? n : 0; }
-function money(n){ try{ return new Intl.NumberFormat('lt-LT',{style:'currency',currency:'EUR'}).format(n||0); }catch{ return `€${(n||0).toFixed(2)}`; } }
+function money(n){
+  try{
+    return new Intl.NumberFormat('lt-LT',{style:'currency',currency:'EUR'}).format(n||0);
+  }catch{
+    return `€${(n||0).toFixed(2)}`;
+  }
+}
 
 const els = {
   shiftHours: document.getElementById('shiftHours'),
@@ -11,12 +17,18 @@ const els = {
   baseRateDoc: document.getElementById('baseRateDoc'),
   baseRateNurse: document.getElementById('baseRateNurse'),
   baseRateAssist: document.getElementById('baseRateAssist'),
-  countDoc: document.getElementById('countDoc'),
-  countNurse: document.getElementById('countNurse'),
-  countAssist: document.getElementById('countAssist'),
-  countDocCell: document.getElementById('countDocCell'),
-  countNurseCell: document.getElementById('countNurseCell'),
-  countAssistCell: document.getElementById('countAssistCell'),
+  countDocDay: document.getElementById('countDocDay'),
+  countDocNight: document.getElementById('countDocNight'),
+  countNurseDay: document.getElementById('countNurseDay'),
+  countNurseNight: document.getElementById('countNurseNight'),
+  countAssistDay: document.getElementById('countAssistDay'),
+  countAssistNight: document.getElementById('countAssistNight'),
+  countDocDayCell: document.getElementById('countDocDayCell'),
+  countDocNightCell: document.getElementById('countDocNightCell'),
+  countNurseDayCell: document.getElementById('countNurseDayCell'),
+  countNurseNightCell: document.getElementById('countNurseNightCell'),
+  countAssistDayCell: document.getElementById('countAssistDayCell'),
+  countAssistNightCell: document.getElementById('countAssistNightCell'),
   rateDocCell: document.getElementById('rateDocCell'),
   rateNurseCell: document.getElementById('rateNurseCell'),
   rateAssistCell: document.getElementById('rateAssistCell'),
@@ -36,11 +48,18 @@ initThemeToggle();
 const budgetChart = createBudgetChart(els.budgetChart, 'doughnut');
 
 function compute(){
+  const docDay = toNum(els.countDocDay.value);
+  const docNight = toNum(els.countDocNight.value);
+  const nurseDay = toNum(els.countNurseDay.value);
+  const nurseNight = toNum(els.countNurseNight.value);
+  const assistDay = toNum(els.countAssistDay.value);
+  const assistNight = toNum(els.countAssistNight.value);
+
   const data = computeBudget({
     counts: {
-      doctor: toNum(els.countDoc.value),
-      nurse: toNum(els.countNurse.value),
-      assistant: toNum(els.countAssist.value),
+      doctor: docDay + docNight,
+      nurse: nurseDay + nurseNight,
+      assistant: assistDay + assistNight,
     },
     rateInputs: {
       zoneCapacity: 1,
@@ -59,9 +78,12 @@ function compute(){
     }
   });
 
-  els.countDocCell.textContent = data.counts.doctor;
-  els.countNurseCell.textContent = data.counts.nurse;
-  els.countAssistCell.textContent = data.counts.assistant;
+  els.countDocDayCell.textContent = docDay;
+  els.countDocNightCell.textContent = docNight;
+  els.countNurseDayCell.textContent = nurseDay;
+  els.countNurseNightCell.textContent = nurseNight;
+  els.countAssistDayCell.textContent = assistDay;
+  els.countAssistNightCell.textContent = assistNight;
 
   els.rateDocCell.textContent = money(data.final_rates.doctor);
   els.rateNurseCell.textContent = money(data.final_rates.nurse);
@@ -81,7 +103,10 @@ function compute(){
 }
 
 ['input','change'].forEach(evt => {
-  ['shiftHours','monthHours','baseRateDoc','baseRateNurse','baseRateAssist','countDoc','countNurse','countAssist'].forEach(id => {
+  [
+    'shiftHours','monthHours','baseRateDoc','baseRateNurse','baseRateAssist',
+    'countDocDay','countDocNight','countNurseDay','countNurseNight','countAssistDay','countAssistNight'
+  ].forEach(id => {
     const el = els[id];
     if (el) el.addEventListener(evt, compute);
   });

--- a/budget.html
+++ b/budget.html
@@ -29,34 +29,46 @@
             <input id="monthHours" type="number" min="0" step="0.5" value="160" />
           </div>
         </div>
-        <div class="row">
+        <div class="row-3">
           <div>
             <label for="baseRateDoc">Bazinis gydytojo tarifas (€ / val.)</label>
             <input id="baseRateDoc" type="number" min="0" step="0.01" value="0" placeholder="pvz. 25.00" />
           </div>
           <div>
-            <label for="countDoc">Gydytojų skaičius</label>
-            <input id="countDoc" type="number" min="0" step="1" value="0" />
+            <label for="countDocDay">Gydytojų (dieną)</label>
+            <input id="countDocDay" type="number" min="0" step="1" value="0" />
+          </div>
+          <div>
+            <label for="countDocNight">Gydytojų (naktį)</label>
+            <input id="countDocNight" type="number" min="0" step="1" value="0" />
           </div>
         </div>
-        <div class="row">
+        <div class="row-3">
           <div>
             <label for="baseRateNurse">Bazinis slaugytojo tarifas (€ / val.)</label>
             <input id="baseRateNurse" type="number" min="0" step="0.01" value="0" placeholder="pvz. 14.00" />
           </div>
           <div>
-            <label for="countNurse">Slaugytojų skaičius</label>
-            <input id="countNurse" type="number" min="0" step="1" value="0" />
+            <label for="countNurseDay">Slaugytojų (dieną)</label>
+            <input id="countNurseDay" type="number" min="0" step="1" value="0" />
+          </div>
+          <div>
+            <label for="countNurseNight">Slaugytojų (naktį)</label>
+            <input id="countNurseNight" type="number" min="0" step="1" value="0" />
           </div>
         </div>
-        <div class="row">
+        <div class="row-3">
           <div>
             <label for="baseRateAssist">Bazinis padėjėjo tarifas (€ / val.)</label>
             <input id="baseRateAssist" type="number" min="0" step="0.01" value="0" placeholder="pvz. 9.00" />
           </div>
           <div>
-            <label for="countAssist">Padėjėjų skaičius</label>
-            <input id="countAssist" type="number" min="0" step="1" value="0" />
+            <label for="countAssistDay">Padėjėjų (dieną)</label>
+            <input id="countAssistDay" type="number" min="0" step="1" value="0" />
+          </div>
+          <div>
+            <label for="countAssistNight">Padėjėjų (naktį)</label>
+            <input id="countAssistNight" type="number" min="0" step="1" value="0" />
           </div>
         </div>
         <div class="actions">
@@ -68,13 +80,13 @@
         <h2>Rezultatai</h2>
         <table class="table">
           <thead>
-            <tr><th>Rolė</th><th>Kiekis</th><th>Tarifas (€/val.)</th><th>Pamainos biudžetas</th><th>Mėnesio biudžetas</th></tr>
+            <tr><th>Rolė</th><th>Diena</th><th>Naktis</th><th>Tarifas (€/val.)</th><th>Pamainos biudžetas</th><th>Mėnesio biudžetas</th></tr>
           </thead>
           <tbody>
-            <tr><td>Gydytojas</td><td id="countDocCell">0</td><td id="rateDocCell">€0,00</td><td id="shiftDocCell">€0,00</td><td id="monthDocCell">€0,00</td></tr>
-            <tr><td>Slaugytojas</td><td id="countNurseCell">0</td><td id="rateNurseCell">€0,00</td><td id="shiftNurseCell">€0,00</td><td id="monthNurseCell">€0,00</td></tr>
-            <tr><td>Padėjėjas</td><td id="countAssistCell">0</td><td id="rateAssistCell">€0,00</td><td id="shiftAssistCell">€0,00</td><td id="monthAssistCell">€0,00</td></tr>
-            <tr><td class="accent">Iš viso</td><td></td><td></td><td class="accent" id="shiftTotalCell">€0,00</td><td class="accent" id="monthTotalCell">€0,00</td></tr>
+            <tr><td>Gydytojas</td><td id="countDocDayCell">0</td><td id="countDocNightCell">0</td><td id="rateDocCell">€0,00</td><td id="shiftDocCell">€0,00</td><td id="monthDocCell">€0,00</td></tr>
+            <tr><td>Slaugytojas</td><td id="countNurseDayCell">0</td><td id="countNurseNightCell">0</td><td id="rateNurseCell">€0,00</td><td id="shiftNurseCell">€0,00</td><td id="monthNurseCell">€0,00</td></tr>
+            <tr><td>Padėjėjas</td><td id="countAssistDayCell">0</td><td id="countAssistNightCell">0</td><td id="rateAssistCell">€0,00</td><td id="shiftAssistCell">€0,00</td><td id="monthAssistCell">€0,00</td></tr>
+            <tr><td class="accent">Iš viso</td><td></td><td></td><td></td><td class="accent" id="shiftTotalCell">€0,00</td><td class="accent" id="monthTotalCell">€0,00</td></tr>
           </tbody>
         </table>
         <div class="kpi">

--- a/budget.js
+++ b/budget.js
@@ -2,7 +2,7 @@ function sanitizeCount(value) {
   return Number.isFinite(value) ? Math.max(0, value) : 0;
 }
 
-import { compute } from './compute';
+import { compute } from './compute.js';
 
 export function computeBudget({ counts = {}, rateInputs = {} }) {
   const salaryData = compute(rateInputs);

--- a/tests/budget.test.js
+++ b/tests/budget.test.js
@@ -118,12 +118,18 @@ describe('budget chart DOM integration', () => {
       <input id="baseRateDoc" value="10" />
       <input id="baseRateNurse" value="8" />
       <input id="baseRateAssist" value="6" />
-      <input id="countDoc" value="1" />
-      <input id="countNurse" value="1" />
-      <input id="countAssist" value="1" />
-      <span id="countDocCell"></span>
-      <span id="countNurseCell"></span>
-      <span id="countAssistCell"></span>
+      <input id="countDocDay" value="1" />
+      <input id="countDocNight" value="1" />
+      <input id="countNurseDay" value="1" />
+      <input id="countNurseNight" value="1" />
+      <input id="countAssistDay" value="1" />
+      <input id="countAssistNight" value="1" />
+      <span id="countDocDayCell"></span>
+      <span id="countDocNightCell"></span>
+      <span id="countNurseDayCell"></span>
+      <span id="countNurseNightCell"></span>
+      <span id="countAssistDayCell"></span>
+      <span id="countAssistNightCell"></span>
       <span id="rateDocCell"></span>
       <span id="rateNurseCell"></span>
       <span id="rateAssistCell"></span>
@@ -169,7 +175,7 @@ describe('budget chart DOM integration', () => {
       n4: 0,
       n5: 0,
     };
-    const initial = computeBudget({ counts: { doctor: 1, nurse: 1, assistant: 1 }, rateInputs }).month_budget;
+    const initial = computeBudget({ counts: { doctor: 2, nurse: 2, assistant: 2 }, rateInputs }).month_budget;
     expect(global.Chart).toHaveBeenCalledTimes(1);
     expect(chartInstance.data.datasets[0].data).toEqual([
       initial.doctor,
@@ -178,9 +184,9 @@ describe('budget chart DOM integration', () => {
     ]);
 
     chartInstance.update.mockClear();
-    document.getElementById('countDoc').value = '2';
+    document.getElementById('countDocDay').value = '2';
     compute();
-    const updated = computeBudget({ counts: { doctor: 2, nurse: 1, assistant: 1 }, rateInputs }).month_budget;
+    const updated = computeBudget({ counts: { doctor: 3, nurse: 2, assistant: 2 }, rateInputs }).month_budget;
     expect(chartInstance.data.datasets[0].data).toEqual([
       updated.doctor,
       updated.nurse,


### PR DESCRIPTION
## Summary
- repair budget module import and currency formatting so the light theme, results and chart render
- allow entering separate day and night staff counts with updated calculations and table
- adjust tests for new staffing fields

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b9a600eea88320835a76a6d71e90b6