### PR TITLE
fix budget planner inputs and theme toggle

### DIFF
--- a/budget-ui.js
+++ b/budget-ui.js
@@ -2,7 +2,11 @@ import { initThemeToggle } from './theme.js';
 import { computeBudget } from './budget.js';
 import { createBudgetChart, updateBudgetChart } from './chart-utils.js';
 
-function toNum(v){ const n = Number(v); return Number.isFinite(n) ? n : 0; }
+function toNum(v){
+  if (typeof v === 'string') v = v.replace(',', '.');
+  const n = Number(v);
+  return Number.isFinite(n) ? n : 0;
+}
 function money(n){
   try{
     return new Intl.NumberFormat('lt-LT',{style:'currency',currency:'EUR'}).format(n||0);

--- a/theme.js
+++ b/theme.js
@@ -1,15 +1,19 @@
 export function initThemeToggle() {
   const THEME_KEY = 'ED_THEME';
+  const root = document.documentElement;
+  const body = document.body;
   const savedTheme = localStorage.getItem(THEME_KEY);
   if (savedTheme === 'light') {
-    document.documentElement.classList.add('light-theme');
+    root.classList.add('light-theme');
+    body.classList.add('light-theme');
   }
   const toggle = document.getElementById('themeToggle');
   if (toggle) {
-    toggle.checked = document.documentElement.classList.contains('light-theme');
+    toggle.checked = root.classList.contains('light-theme');
     toggle.addEventListener('change', () => {
       const isLight = toggle.checked;
-      document.documentElement.classList.toggle('light-theme', isLight);
+      root.classList.toggle('light-theme', isLight);
+      body.classList.toggle('light-theme', isLight);
       localStorage.setItem(THEME_KEY, isLight ? 'light' : 'dark');
     });
   }


### PR DESCRIPTION
## Summary
- allow comma decimal inputs in budget planner
- ensure theme toggle applies light theme styling

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b9a819f0948320adc099ca7058c4e2