### PR TITLE
feat: split day and night budgets

### DIFF
--- a/budget-ui.js
+++ b/budget-ui.js
@@ -36,13 +36,29 @@ const els = {
   rateDocCell: document.getElementById('rateDocCell'),
   rateNurseCell: document.getElementById('rateNurseCell'),
   rateAssistCell: document.getElementById('rateAssistCell'),
+  shiftDocDayCell: document.getElementById('shiftDocDayCell'),
+  shiftDocNightCell: document.getElementById('shiftDocNightCell'),
   shiftDocCell: document.getElementById('shiftDocCell'),
+  shiftNurseDayCell: document.getElementById('shiftNurseDayCell'),
+  shiftNurseNightCell: document.getElementById('shiftNurseNightCell'),
   shiftNurseCell: document.getElementById('shiftNurseCell'),
+  shiftAssistDayCell: document.getElementById('shiftAssistDayCell'),
+  shiftAssistNightCell: document.getElementById('shiftAssistNightCell'),
   shiftAssistCell: document.getElementById('shiftAssistCell'),
+  monthDocDayCell: document.getElementById('monthDocDayCell'),
+  monthDocNightCell: document.getElementById('monthDocNightCell'),
   monthDocCell: document.getElementById('monthDocCell'),
+  monthNurseDayCell: document.getElementById('monthNurseDayCell'),
+  monthNurseNightCell: document.getElementById('monthNurseNightCell'),
   monthNurseCell: document.getElementById('monthNurseCell'),
+  monthAssistDayCell: document.getElementById('monthAssistDayCell'),
+  monthAssistNightCell: document.getElementById('monthAssistNightCell'),
   monthAssistCell: document.getElementById('monthAssistCell'),
+  shiftDayTotalCell: document.getElementById('shiftDayTotalCell'),
+  shiftNightTotalCell: document.getElementById('shiftNightTotalCell'),
   shiftTotalCell: document.getElementById('shiftTotalCell'),
+  monthDayTotalCell: document.getElementById('monthDayTotalCell'),
+  monthNightTotalCell: document.getElementById('monthNightTotalCell'),
   monthTotalCell: document.getElementById('monthTotalCell'),
   budgetChart: document.getElementById('budgetChart'),
 };
@@ -100,14 +116,30 @@ function compute(){
   els.rateNurseCell.textContent = money(data.final_rates.nurse);
   els.rateAssistCell.textContent = money(data.final_rates.assistant);
 
+  if (els.shiftDocDayCell) els.shiftDocDayCell.textContent = money(data.shift_budget_day.doctor);
+  if (els.shiftDocNightCell) els.shiftDocNightCell.textContent = money(data.shift_budget_night.doctor);
   els.shiftDocCell.textContent = money(data.shift_budget.doctor);
+  if (els.shiftNurseDayCell) els.shiftNurseDayCell.textContent = money(data.shift_budget_day.nurse);
+  if (els.shiftNurseNightCell) els.shiftNurseNightCell.textContent = money(data.shift_budget_night.nurse);
   els.shiftNurseCell.textContent = money(data.shift_budget.nurse);
+  if (els.shiftAssistDayCell) els.shiftAssistDayCell.textContent = money(data.shift_budget_day.assistant);
+  if (els.shiftAssistNightCell) els.shiftAssistNightCell.textContent = money(data.shift_budget_night.assistant);
   els.shiftAssistCell.textContent = money(data.shift_budget.assistant);
+  if (els.shiftDayTotalCell) els.shiftDayTotalCell.textContent = money(data.shift_budget_day.total);
+  if (els.shiftNightTotalCell) els.shiftNightTotalCell.textContent = money(data.shift_budget_night.total);
   els.shiftTotalCell.textContent = money(data.shift_budget.total);
 
+  if (els.monthDocDayCell) els.monthDocDayCell.textContent = money(data.month_budget_day.doctor);
+  if (els.monthDocNightCell) els.monthDocNightCell.textContent = money(data.month_budget_night.doctor);
   els.monthDocCell.textContent = money(data.month_budget.doctor);
+  if (els.monthNurseDayCell) els.monthNurseDayCell.textContent = money(data.month_budget_day.nurse);
+  if (els.monthNurseNightCell) els.monthNurseNightCell.textContent = money(data.month_budget_night.nurse);
   els.monthNurseCell.textContent = money(data.month_budget.nurse);
+  if (els.monthAssistDayCell) els.monthAssistDayCell.textContent = money(data.month_budget_day.assistant);
+  if (els.monthAssistNightCell) els.monthAssistNightCell.textContent = money(data.month_budget_night.assistant);
   els.monthAssistCell.textContent = money(data.month_budget.assistant);
+  if (els.monthDayTotalCell) els.monthDayTotalCell.textContent = money(data.month_budget_day.total);
+  if (els.monthNightTotalCell) els.monthNightTotalCell.textContent = money(data.month_budget_night.total);
   els.monthTotalCell.textContent = money(data.month_budget.total);
 
   updateBudgetChart(budgetChart, data.month_budget);

--- a/budget.html
+++ b/budget.html
@@ -80,13 +80,68 @@
         <h2>Rezultatai</h2>
         <table class="table">
           <thead>
-            <tr><th>Rolė</th><th>Diena</th><th>Naktis</th><th>Tarifas (€/val.)</th><th>Pamainos biudžetas</th><th>Mėnesio biudžetas</th></tr>
+            <tr>
+              <th>Rolė</th>
+              <th>Diena</th>
+              <th>Naktis</th>
+              <th>Tarifas (€/val.)</th>
+              <th>Pamainos biudžetas (dieną)</th>
+              <th>Pamainos biudžetas (naktį)</th>
+              <th>Pamainos biudžetas (viso)</th>
+              <th>Mėnesio biudžetas (dieną)</th>
+              <th>Mėnesio biudžetas (naktį)</th>
+              <th>Mėnesio biudžetas (viso)</th>
+            </tr>
           </thead>
           <tbody>
-            <tr><td>Gydytojas</td><td id="countDocDayCell">0</td><td id="countDocNightCell">0</td><td id="rateDocCell">€0,00</td><td id="shiftDocCell">€0,00</td><td id="monthDocCell">€0,00</td></tr>
-            <tr><td>Slaugytojas</td><td id="countNurseDayCell">0</td><td id="countNurseNightCell">0</td><td id="rateNurseCell">€0,00</td><td id="shiftNurseCell">€0,00</td><td id="monthNurseCell">€0,00</td></tr>
-            <tr><td>Padėjėjas</td><td id="countAssistDayCell">0</td><td id="countAssistNightCell">0</td><td id="rateAssistCell">€0,00</td><td id="shiftAssistCell">€0,00</td><td id="monthAssistCell">€0,00</td></tr>
-            <tr><td class="accent">Iš viso</td><td></td><td></td><td></td><td class="accent" id="shiftTotalCell">€0,00</td><td class="accent" id="monthTotalCell">€0,00</td></tr>
+            <tr>
+              <td>Gydytojas</td>
+              <td id="countDocDayCell">0</td>
+              <td id="countDocNightCell">0</td>
+              <td id="rateDocCell">€0,00</td>
+              <td id="shiftDocDayCell">€0,00</td>
+              <td id="shiftDocNightCell">€0,00</td>
+              <td id="shiftDocCell">€0,00</td>
+              <td id="monthDocDayCell">€0,00</td>
+              <td id="monthDocNightCell">€0,00</td>
+              <td id="monthDocCell">€0,00</td>
+            </tr>
+            <tr>
+              <td>Slaugytojas</td>
+              <td id="countNurseDayCell">0</td>
+              <td id="countNurseNightCell">0</td>
+              <td id="rateNurseCell">€0,00</td>
+              <td id="shiftNurseDayCell">€0,00</td>
+              <td id="shiftNurseNightCell">€0,00</td>
+              <td id="shiftNurseCell">€0,00</td>
+              <td id="monthNurseDayCell">€0,00</td>
+              <td id="monthNurseNightCell">€0,00</td>
+              <td id="monthNurseCell">€0,00</td>
+            </tr>
+            <tr>
+              <td>Padėjėjas</td>
+              <td id="countAssistDayCell">0</td>
+              <td id="countAssistNightCell">0</td>
+              <td id="rateAssistCell">€0,00</td>
+              <td id="shiftAssistDayCell">€0,00</td>
+              <td id="shiftAssistNightCell">€0,00</td>
+              <td id="shiftAssistCell">€0,00</td>
+              <td id="monthAssistDayCell">€0,00</td>
+              <td id="monthAssistNightCell">€0,00</td>
+              <td id="monthAssistCell">€0,00</td>
+            </tr>
+            <tr>
+              <td class="accent">Iš viso</td>
+              <td></td>
+              <td></td>
+              <td></td>
+              <td class="accent" id="shiftDayTotalCell">€0,00</td>
+              <td class="accent" id="shiftNightTotalCell">€0,00</td>
+              <td class="accent" id="shiftTotalCell">€0,00</td>
+              <td class="accent" id="monthDayTotalCell">€0,00</td>
+              <td class="accent" id="monthNightTotalCell">€0,00</td>
+              <td class="accent" id="monthTotalCell">€0,00</td>
+            </tr>
           </tbody>
         </table>
         <div class="kpi">

--- a/budget.js
+++ b/budget.js
@@ -9,9 +9,17 @@ export function computeBudget({ counts = {}, rateInputs = {}, nightMultiplier = 
   const roles = ['doctor', 'nurse', 'assistant'];
 
   const cleanCounts = {};
+  const shift_budget_day = {};
+  const shift_budget_night = {};
   const shift_budget = {};
+  const month_budget_day = {};
+  const month_budget_night = {};
   const month_budget = {};
+  let shift_day_total = 0;
+  let shift_night_total = 0;
   let shift_total = 0;
+  let month_day_total = 0;
+  let month_night_total = 0;
   let month_total = 0;
 
   for (const role of roles) {
@@ -26,22 +34,45 @@ export function computeBudget({ counts = {}, rateInputs = {}, nightMultiplier = 
     }
     const total = day + night;
     cleanCounts[role] = total;
-    const factorCount = day + night * nightMultiplier;
-    const shift = (salaryData.shift_salary?.[role] || 0) * factorCount;
-    const month = (salaryData.month_salary?.[role] || 0) * factorCount;
-    shift_budget[role] = shift;
-    month_budget[role] = month;
-    shift_total += shift;
-    month_total += month;
+
+    const baseShift = salaryData.shift_salary?.[role] || 0;
+    const baseMonth = salaryData.month_salary?.[role] || 0;
+
+    const shiftDay = baseShift * day;
+    const shiftNight = baseShift * night * nightMultiplier;
+    const monthDay = baseMonth * day;
+    const monthNight = baseMonth * night * nightMultiplier;
+
+    shift_budget_day[role] = shiftDay;
+    shift_budget_night[role] = shiftNight;
+    shift_budget[role] = shiftDay + shiftNight;
+    month_budget_day[role] = monthDay;
+    month_budget_night[role] = monthNight;
+    month_budget[role] = monthDay + monthNight;
+
+    shift_day_total += shiftDay;
+    shift_night_total += shiftNight;
+    shift_total += shiftDay + shiftNight;
+    month_day_total += monthDay;
+    month_night_total += monthNight;
+    month_total += monthDay + monthNight;
   }
 
+  shift_budget_day.total = shift_day_total;
+  shift_budget_night.total = shift_night_total;
   shift_budget.total = shift_total;
+  month_budget_day.total = month_day_total;
+  month_budget_night.total = month_night_total;
   month_budget.total = month_total;
 
   return {
     ...salaryData,
     counts: cleanCounts,
+    shift_budget_day,
+    shift_budget_night,
     shift_budget,
+    month_budget_day,
+    month_budget_night,
     month_budget,
   };
 }

--- a/tests/budget.test.js
+++ b/tests/budget.test.js
@@ -23,10 +23,12 @@ describe('computeBudget', () => {
       },
     });
 
-    expect(result.shift_budget.doctor).toBeCloseTo(240);
-    expect(result.shift_budget.nurse).toBeCloseTo(288);
-    expect(result.shift_budget.assistant).toBeCloseTo(72);
+    expect(result.shift_budget_day.doctor).toBeCloseTo(240);
+    expect(result.shift_budget_day.nurse).toBeCloseTo(288);
+    expect(result.shift_budget_day.assistant).toBeCloseTo(72);
+    expect(result.shift_budget_night.total).toBeCloseTo(0);
     expect(result.shift_budget.total).toBeCloseTo(600);
+    expect(result.month_budget_day.total).toBeCloseTo(8000);
     expect(result.month_budget.total).toBeCloseTo(8000);
   });
 
@@ -50,9 +52,9 @@ describe('computeBudget', () => {
       },
     });
 
-    expect(result.shift_budget.doctor).toBe(0);
-    expect(result.shift_budget.nurse).toBe(0);
-    expect(result.shift_budget.assistant).toBeCloseTo(72);
+    expect(result.shift_budget_day.doctor).toBe(0);
+    expect(result.shift_budget_day.nurse).toBe(0);
+    expect(result.shift_budget_day.assistant).toBeCloseTo(72);
     expect(result.shift_budget.total).toBeCloseTo(72);
   });
   test('applies night multiplier', () => {
@@ -78,7 +80,11 @@ describe('computeBudget', () => {
       },
     });
 
+    expect(result.shift_budget_day.doctor).toBeCloseTo(10);
+    expect(result.shift_budget_night.doctor).toBeCloseTo(15);
     expect(result.shift_budget.doctor).toBeCloseTo(25);
+    expect(result.month_budget_day.doctor).toBeCloseTo(10);
+    expect(result.month_budget_night.doctor).toBeCloseTo(15);
     expect(result.month_budget.doctor).toBeCloseTo(25);
   });
 });
@@ -159,13 +165,29 @@ describe('budget chart DOM integration', () => {
       <span id="rateDocCell"></span>
       <span id="rateNurseCell"></span>
       <span id="rateAssistCell"></span>
+      <span id="shiftDocDayCell"></span>
+      <span id="shiftDocNightCell"></span>
       <span id="shiftDocCell"></span>
+      <span id="shiftNurseDayCell"></span>
+      <span id="shiftNurseNightCell"></span>
       <span id="shiftNurseCell"></span>
+      <span id="shiftAssistDayCell"></span>
+      <span id="shiftAssistNightCell"></span>
       <span id="shiftAssistCell"></span>
+      <span id="monthDocDayCell"></span>
+      <span id="monthDocNightCell"></span>
       <span id="monthDocCell"></span>
+      <span id="monthNurseDayCell"></span>
+      <span id="monthNurseNightCell"></span>
       <span id="monthNurseCell"></span>
+      <span id="monthAssistDayCell"></span>
+      <span id="monthAssistNightCell"></span>
       <span id="monthAssistCell"></span>
+      <span id="shiftDayTotalCell"></span>
+      <span id="shiftNightTotalCell"></span>
       <span id="shiftTotalCell"></span>
+      <span id="monthDayTotalCell"></span>
+      <span id="monthNightTotalCell"></span>
       <span id="monthTotalCell"></span>
       <canvas id="budgetChart"></canvas>
     `;


### PR DESCRIPTION
## Summary
- compute day and night budgets separately for each role
- display separate day/night budgets in budget results table
- update tests for new budgeting

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b9be9aa2248320a51ff0e7d9d9d65a