### PR TITLE
Persist budget inputs

### DIFF
--- a/budget-ui.js
+++ b/budget-ui.js
@@ -67,6 +67,33 @@ initThemeToggle();
 
 const budgetChart = createBudgetChart(els.budgetChart, 'doughnut');
 
+const INPUT_IDS = [
+  'shiftHours','monthHours','baseRateDoc','baseRateNurse','baseRateAssist',
+  'countDocDay','countDocNight','countNurseDay','countNurseNight','countAssistDay','countAssistNight'
+];
+const STORAGE_KEY = 'budgetInputs';
+
+function loadInputs(){
+  if (typeof localStorage === 'undefined') return;
+  try{
+    const saved = JSON.parse(localStorage.getItem(STORAGE_KEY)) || {};
+    INPUT_IDS.forEach(id => {
+      if (els[id] && saved[id] !== undefined) els[id].value = saved[id];
+    });
+  }catch{}
+}
+
+function saveInputs(){
+  if (typeof localStorage === 'undefined') return;
+  const data = {};
+  INPUT_IDS.forEach(id => {
+    if (els[id]) data[id] = els[id].value;
+  });
+  try{
+    localStorage.setItem(STORAGE_KEY, JSON.stringify(data));
+  }catch{}
+}
+
 function compute(){
   const docDay = toNum(els.countDocDay.value);
   const docNight = toNum(els.countDocNight.value);
@@ -146,17 +173,18 @@ function compute(){
 }
 
 ['input','change'].forEach(evt => {
-  [
-    'shiftHours','monthHours','baseRateDoc','baseRateNurse','baseRateAssist',
-    'countDocDay','countDocNight','countNurseDay','countNurseNight','countAssistDay','countAssistNight'
-  ].forEach(id => {
+  INPUT_IDS.forEach(id => {
     const el = els[id];
-    if (el) el.addEventListener(evt, compute);
+    if (el) el.addEventListener(evt, () => {
+      saveInputs();
+      compute();
+    });
   });
 });
 
+loadInputs();
 compute();
 
 if (typeof module !== 'undefined') {
-  module.exports = { compute };
+  module.exports = { compute, loadInputs, saveInputs };
 }

--- a/tests/budget-ui.test.js
+++ b/tests/budget-ui.test.js
@@ -1,0 +1,44 @@
+const inputIds = [
+  'shiftHours','monthHours','baseRateDoc','baseRateNurse','baseRateAssist',
+  'countDocDay','countDocNight','countNurseDay','countNurseNight','countAssistDay','countAssistNight'
+];
+const cellIds = [
+  'countDocDayCell','countDocNightCell','countNurseDayCell','countNurseNightCell','countAssistDayCell','countAssistNightCell',
+  'rateDocCell','rateNurseCell','rateAssistCell','shiftDocDayCell','shiftDocNightCell','shiftDocCell','shiftNurseDayCell',
+  'shiftNurseNightCell','shiftNurseCell','shiftAssistDayCell','shiftAssistNightCell','shiftAssistCell','monthDocDayCell',
+  'monthDocNightCell','monthDocCell','monthNurseDayCell','monthNurseNightCell','monthNurseCell','monthAssistDayCell',
+  'monthAssistNightCell','monthAssistCell','shiftDayTotalCell','shiftNightTotalCell','shiftTotalCell','monthDayTotalCell',
+  'monthNightTotalCell','monthTotalCell'
+];
+
+function setupDOM(){
+  let html = '';
+  inputIds.forEach(id => { html += `<input id="${id}" />`; });
+  cellIds.forEach(id => { html += `<div id="${id}"></div>`; });
+  html += '<canvas id="budgetChart"></canvas>';
+  document.body.innerHTML = html;
+}
+
+beforeEach(() => {
+  document.body.innerHTML = '';
+  localStorage.clear();
+  jest.resetModules();
+});
+
+test('loads saved values from localStorage', () => {
+  setupDOM();
+  localStorage.setItem('budgetInputs', JSON.stringify({ shiftHours: '8', monthHours: '160' }));
+  require('../budget-ui.js');
+  expect(document.getElementById('shiftHours').value).toBe('8');
+  expect(document.getElementById('monthHours').value).toBe('160');
+});
+
+test('saves inputs to localStorage on input', () => {
+  setupDOM();
+  require('../budget-ui.js');
+  const shift = document.getElementById('shiftHours');
+  shift.value = '12';
+  shift.dispatchEvent(new Event('input'));
+  const saved = JSON.parse(localStorage.getItem('budgetInputs'));
+  expect(saved.shiftHours).toBe('12');
+});


### PR DESCRIPTION
## Summary
- Persist budget form values in localStorage under `budgetInputs`
- Restore saved values on load and update store on input/change
- Add tests for loading and saving budget inputs

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b9c456fce88320aa8002fc36c3d6a3