### PR TITLE
Add stacked day/night budget chart and tests

### DIFF
--- a/budget-ui.js
+++ b/budget-ui.js
@@ -1,6 +1,6 @@
 import { initThemeToggle } from './theme.js';
 import { computeBudget } from './budget.js';
-import { createBudgetChart, updateBudgetChart } from './chart-utils.js';
+import { createBudgetChart, updateBudgetChart, createDayNightChart, updateDayNightChart } from './chart-utils.js';
 
 function toNum(v){
   if (typeof v === 'string') v = v.replace(',', '.');
@@ -61,11 +61,13 @@ const els = {
   monthNightTotalCell: document.getElementById('monthNightTotalCell'),
   monthTotalCell: document.getElementById('monthTotalCell'),
   budgetChart: document.getElementById('budgetChart'),
+  dayNightChart: document.getElementById('dayNightChart'),
 };
 
 initThemeToggle();
 
 const budgetChart = createBudgetChart(els.budgetChart, 'doughnut');
+const dayNightChart = createDayNightChart(els.dayNightChart);
 
 const INPUT_IDS = [
   'shiftHours','monthHours','baseRateDoc','baseRateNurse','baseRateAssist',
@@ -170,6 +172,7 @@ function compute(){
   els.monthTotalCell.textContent = money(data.month_budget.total);
 
   updateBudgetChart(budgetChart, data.month_budget);
+  updateDayNightChart(dayNightChart, data.shift_budget_day, data.shift_budget_night);
 }
 
 ['input','change'].forEach(evt => {

--- a/budget.html
+++ b/budget.html
@@ -148,6 +148,7 @@
           <div class="item budget-chart">
             <div class="label">Biudžeto grafikas</div>
             <canvas id="budgetChart" width="480" height="240"></canvas>
+            <canvas id="dayNightChart" width="480" height="240"></canvas>
           </div>
         </div>
       </div>

--- a/chart-utils.js
+++ b/chart-utils.js
@@ -61,6 +61,40 @@ export function updateBudgetChart(chart, budgets = {}) {
   });
 }
 
+export function createDayNightChart(canvas) {
+  if (!canvas || typeof Chart === 'undefined') return null;
+  const ctx = canvas.getContext && canvas.getContext('2d');
+  if (!ctx) return null;
+  return new Chart(ctx, {
+    type: 'bar',
+    data: {
+      labels: ['Gydytojas', 'Slaugytojas', 'Padėjėjas'],
+      datasets: [
+        { label: 'Diena', data: [0, 0, 0], backgroundColor: '#007bff' },
+        { label: 'Naktis', data: [0, 0, 0], backgroundColor: '#6c757d' },
+      ]
+    },
+    options: {
+      responsive: true,
+      maintainAspectRatio: false,
+      plugins: { legend: { display: true } },
+      scales: {
+        x: { stacked: true },
+        y: { stacked: true, beginAtZero: true }
+      }
+    }
+  });
+}
+
+export function updateDayNightChart(chart, day = {}, night = {}) {
+  const roles = ['doctor', 'nurse', 'assistant'];
+  updateChart(chart, c => {
+    c.data.datasets[0].data = roles.map(r => Number(day[r]) || 0);
+    c.data.datasets[1].data = roles.map(r => Number(night[r]) || 0);
+    c.update();
+  });
+}
+
 // CommonJS support for tests
 if (typeof module !== 'undefined') {
   module.exports = {
@@ -69,5 +103,7 @@ if (typeof module !== 'undefined') {
     updateFlowChart,
     createBudgetChart,
     updateBudgetChart,
+    createDayNightChart,
+    updateDayNightChart,
   };
 }

--- a/tests/chart-utils.test.js
+++ b/tests/chart-utils.test.js
@@ -4,6 +4,8 @@ import {
   updateFlowChart,
   createBudgetChart,
   updateBudgetChart,
+  createDayNightChart,
+  updateDayNightChart,
 } from '../chart-utils.js';
 
 describe('updateChart', () => {
@@ -78,6 +80,33 @@ describe('updateBudgetChart', () => {
     const chart = { data: { datasets: [{ data: [] }] }, update: jest.fn() };
     updateBudgetChart(chart, { doctor: 10, nurse: 20, assistant: 30 });
     expect(chart.data.datasets[0].data).toEqual([10,20,30]);
+    expect(chart.update).toHaveBeenCalled();
+  });
+});
+
+describe('createDayNightChart', () => {
+  test('returns null without canvas', () => {
+    expect(createDayNightChart(null)).toBeNull();
+  });
+
+  test('creates chart when Chart is available', () => {
+    const ctx = {};
+    const canvas = { getContext: jest.fn(() => ctx) };
+    global.Chart = jest.fn(() => ({ data: { labels: [], datasets: [{ data: [] }, { data: [] }] }, update: jest.fn() }));
+    const chart = createDayNightChart(canvas);
+    expect(canvas.getContext).toHaveBeenCalledWith('2d');
+    expect(global.Chart).toHaveBeenCalled();
+    expect(chart).toBeTruthy();
+    delete global.Chart;
+  });
+});
+
+describe('updateDayNightChart', () => {
+  test('updates chart data and calls update', () => {
+    const chart = { data: { datasets: [{ data: [] }, { data: [] }] }, update: jest.fn() };
+    updateDayNightChart(chart, { doctor: 1, nurse: 2, assistant: 3 }, { doctor: 4, nurse: 5, assistant: 6 });
+    expect(chart.data.datasets[0].data).toEqual([1,2,3]);
+    expect(chart.data.datasets[1].data).toEqual([4,5,6]);
     expect(chart.update).toHaveBeenCalled();
   });
 });


### PR DESCRIPTION
## Summary
- Add a second canvas in budget page to display day vs night shift costs
- Implement helper utilities for stacked day/night budget chart
- Update UI logic to render and refresh new chart
- Extend chart-utils tests to cover day/night chart creation and updating

## Testing
- `npm test` *(fails: npm not installed)*

------
https://chatgpt.com/codex/tasks/task_e_68b9c731975c832081e98b228cc5c6ae