### PR TITLE
Add staff distribution chart and tests

### DIFF
--- a/budget-ui.js
+++ b/budget-ui.js
@@ -1,6 +1,6 @@
 import { initThemeToggle } from './theme.js';
 import { computeBudget } from './budget.js';
-import { createBudgetChart, updateBudgetChart, createDayNightChart, updateDayNightChart } from './chart-utils.js';
+import { createBudgetChart, updateBudgetChart, createDayNightChart, updateDayNightChart, createStaffChart, updateStaffChart } from './chart-utils.js';
 
 function toNum(v){
   if (typeof v === 'string') v = v.replace(',', '.');
@@ -62,12 +62,14 @@ const els = {
   monthTotalCell: document.getElementById('monthTotalCell'),
   budgetChart: document.getElementById('budgetChart'),
   dayNightChart: document.getElementById('dayNightChart'),
+  staffChart: document.getElementById('staffChart'),
 };
 
 initThemeToggle();
 
 const budgetChart = createBudgetChart(els.budgetChart, 'doughnut');
 const dayNightChart = createDayNightChart(els.dayNightChart);
+const staffChart = createStaffChart(els.staffChart);
 
 const INPUT_IDS = [
   'shiftHours','monthHours','baseRateDoc','baseRateNurse','baseRateAssist',
@@ -104,19 +106,21 @@ function compute(){
   const assistDay = toNum(els.countAssistDay.value);
   const assistNight = toNum(els.countAssistNight.value);
 
-  const data = computeBudget({
-    counts: {
-      day: {
-        doctor: docDay,
-        nurse: nurseDay,
-        assistant: assistDay,
-      },
-      night: {
-        doctor: docNight,
-        nurse: nurseNight,
-        assistant: assistNight,
-      },
+  const counts = {
+    day: {
+      doctor: docDay,
+      nurse: nurseDay,
+      assistant: assistDay,
     },
+    night: {
+      doctor: docNight,
+      nurse: nurseNight,
+      assistant: assistNight,
+    },
+  };
+
+  const data = computeBudget({
+    counts,
     rateInputs: {
       zoneCapacity: 1,
       patientCount: 0,
@@ -173,6 +177,7 @@ function compute(){
 
   updateBudgetChart(budgetChart, data.month_budget);
   updateDayNightChart(dayNightChart, data.shift_budget_day, data.shift_budget_night);
+  updateStaffChart(staffChart, counts);
 }
 
 ['input','change'].forEach(evt => {

--- a/budget.html
+++ b/budget.html
@@ -149,6 +149,7 @@
             <div class="label">Biudžeto grafikas</div>
             <canvas id="budgetChart" width="480" height="240"></canvas>
             <canvas id="dayNightChart" width="480" height="240"></canvas>
+            <canvas id="staffChart" width="480" height="240"></canvas>
           </div>
         </div>
       </div>

--- a/chart-utils.js
+++ b/chart-utils.js
@@ -95,6 +95,42 @@ export function updateDayNightChart(chart, day = {}, night = {}) {
   });
 }
 
+export function createStaffChart(canvas) {
+  if (!canvas || typeof Chart === 'undefined') return null;
+  const ctx = canvas.getContext && canvas.getContext('2d');
+  if (!ctx) return null;
+  const colors = ['#007bff', '#28a745', '#ffc107'];
+  return new Chart(ctx, {
+    type: 'doughnut',
+    data: {
+      labels: ['Gydytojas', 'Slaugytojas', 'Padėjėjas'],
+      datasets: [{
+        label: 'Personalas',
+        data: [0, 0, 0],
+        backgroundColor: colors,
+        borderColor: colors,
+      }]
+    },
+    options: {
+      plugins: { legend: { display: true } },
+      maintainAspectRatio: false,
+      responsive: true,
+    }
+  });
+}
+
+export function updateStaffChart(chart, counts = { day: {}, night: {} }) {
+  const roles = ['doctor', 'nurse', 'assistant'];
+  updateChart(chart, c => {
+    c.data.datasets[0].data = roles.map(r => {
+      const day = Number((counts.day && counts.day[r]) || 0);
+      const night = Number((counts.night && counts.night[r]) || 0);
+      return day + night;
+    });
+    c.update();
+  });
+}
+
 // CommonJS support for tests
 if (typeof module !== 'undefined') {
   module.exports = {
@@ -105,5 +141,7 @@ if (typeof module !== 'undefined') {
     updateBudgetChart,
     createDayNightChart,
     updateDayNightChart,
+    createStaffChart,
+    updateStaffChart,
   };
 }

--- a/tests/budget-ui.test.js
+++ b/tests/budget-ui.test.js
@@ -1,3 +1,16 @@
+jest.mock('../chart-utils.js', () => {
+  const actual = jest.requireActual('../chart-utils.js');
+  return {
+    ...actual,
+    createBudgetChart: jest.fn(() => ({})),
+    updateBudgetChart: jest.fn(),
+    createDayNightChart: jest.fn(() => ({})),
+    updateDayNightChart: jest.fn(),
+    createStaffChart: jest.fn(() => ({ data: { datasets: [{ data: [] }] }, update: jest.fn() })),
+    updateStaffChart: jest.fn(),
+  };
+});
+
 const inputIds = [
   'shiftHours','monthHours','baseRateDoc','baseRateNurse','baseRateAssist',
   'countDocDay','countDocNight','countNurseDay','countNurseNight','countAssistDay','countAssistNight'
@@ -16,6 +29,8 @@ function setupDOM(){
   inputIds.forEach(id => { html += `<input id="${id}" />`; });
   cellIds.forEach(id => { html += `<div id="${id}"></div>`; });
   html += '<canvas id="budgetChart"></canvas>';
+  html += '<canvas id="dayNightChart"></canvas>';
+  html += '<canvas id="staffChart"></canvas>';
   document.body.innerHTML = html;
 }
 
@@ -41,4 +56,24 @@ test('saves inputs to localStorage on input', () => {
   shift.dispatchEvent(new Event('input'));
   const saved = JSON.parse(localStorage.getItem('budgetInputs'));
   expect(saved.shiftHours).toBe('12');
+});
+
+test('computes and updates staff chart with counts', () => {
+  setupDOM();
+  const { compute } = require('../budget-ui.js');
+  const { updateStaffChart } = require('../chart-utils.js');
+
+  document.getElementById('countDocDay').value = '1';
+  document.getElementById('countDocNight').value = '2';
+  document.getElementById('countNurseDay').value = '3';
+  document.getElementById('countNurseNight').value = '4';
+  document.getElementById('countAssistDay').value = '5';
+  document.getElementById('countAssistNight').value = '6';
+
+  compute();
+
+  expect(updateStaffChart).toHaveBeenCalledWith(expect.anything(), {
+    day: { doctor: 1, nurse: 3, assistant: 5 },
+    night: { doctor: 2, nurse: 4, assistant: 6 },
+  });
 });

--- a/tests/chart-utils.test.js
+++ b/tests/chart-utils.test.js
@@ -6,6 +6,8 @@ import {
   updateBudgetChart,
   createDayNightChart,
   updateDayNightChart,
+  createStaffChart,
+  updateStaffChart,
 } from '../chart-utils.js';
 
 describe('updateChart', () => {
@@ -107,6 +109,36 @@ describe('updateDayNightChart', () => {
     updateDayNightChart(chart, { doctor: 1, nurse: 2, assistant: 3 }, { doctor: 4, nurse: 5, assistant: 6 });
     expect(chart.data.datasets[0].data).toEqual([1,2,3]);
     expect(chart.data.datasets[1].data).toEqual([4,5,6]);
+    expect(chart.update).toHaveBeenCalled();
+  });
+});
+
+describe('createStaffChart', () => {
+  test('returns null without canvas', () => {
+    expect(createStaffChart(null)).toBeNull();
+  });
+
+  test('creates chart when Chart is available', () => {
+    const ctx = {};
+    const canvas = { getContext: jest.fn(() => ctx) };
+    global.Chart = jest.fn(() => ({ data: { datasets: [{ data: [] }] }, update: jest.fn() }));
+    const chart = createStaffChart(canvas);
+    expect(canvas.getContext).toHaveBeenCalledWith('2d');
+    expect(global.Chart).toHaveBeenCalled();
+    expect(chart).toBeTruthy();
+    delete global.Chart;
+  });
+});
+
+describe('updateStaffChart', () => {
+  test('aggregates day and night counts and updates chart', () => {
+    const chart = { data: { datasets: [{ data: [] }] }, update: jest.fn() };
+    const counts = {
+      day: { doctor: 1, nurse: 2, assistant: 3 },
+      night: { doctor: 4, nurse: 5, assistant: 6 },
+    };
+    updateStaffChart(chart, counts);
+    expect(chart.data.datasets[0].data).toEqual([5,7,9]);
     expect(chart.update).toHaveBeenCalled();
   });
 });


### PR DESCRIPTION
## Summary
- Display staff composition with new doughnut chart on budget page
- Aggregate day and night staff counts for chart rendering
- Test staff chart aggregation and integration with compute

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b9d777216083208d9b274cbfdb11ed