### PR TITLE
Make budget chart height responsive

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -100,7 +100,11 @@
     @media (min-width: 960px) { .kpi .pay-chart { grid-column: 1 / -1; } }
     .kpi .flow-chart canvas { max-width: none; height: 240px !important; }
     @media (min-width: 960px) { .kpi .flow-chart { grid-column: 1 / -1; } }
-    .kpi .budget-chart canvas { max-width: none; height: 240px !important; }
+    .kpi .budget-chart canvas {
+      max-width: none;
+      height: auto !important;
+      aspect-ratio: 2 / 1;
+    }
     @media (min-width: 960px) { .kpi .budget-chart { grid-column: 1 / -1; } }
     .pill { display:inline-block; padding: 4px 8px; border-radius: 999px; font-size: var(--font-xs); border:1px solid var(--border); background:var(--panel); }
     .accent { color: var(--accent); }


### PR DESCRIPTION
## Summary
- allow budget charts to scale vertically with container width via CSS aspect-ratio

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b9d8f2d2008320bc5a76a546d62c0e