### PR TITLE
Enable full-page scrolling

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -30,13 +30,14 @@
       --drag: #cbd5e1;      /* slate-300 */
     }
     * { box-sizing: border-box; }
-    html, body { height: 100%; overflow: hidden; }
+    html, body { height: 100%; }
     body {
       margin: 0; font-family: system-ui, -apple-system, Segoe UI, Roboto, Ubuntu, "Helvetica Neue", Arial;
       background: linear-gradient(135deg, var(--bg), #0b1020 60%, #0a0f1a);
       color: var(--text);
       display: flex;
       flex-direction: column;
+      overflow-y: auto;
     }
 
     .light-theme body {
@@ -51,7 +52,6 @@
       flex: 1;
       display: flex;
       flex-direction: column;
-      overflow: hidden;
     }
     .title { display: flex; align-items: center; gap: 12px; flex-wrap: wrap; flex-shrink: 0; }
     .title .switch { margin-left: auto; }
@@ -67,7 +67,7 @@
       border: 1px solid var(--border);
       border-radius: 16px; padding: 18px;
       box-shadow: 0 10px 30px rgba(0,0,0,0.35), inset 0 1px 0 rgba(255,255,255,0.02);
-      overflow: auto;
+      height: inherit;
     }
     h1 { font-size: var(--font-xl); margin: 6px 0 2px; letter-spacing: 0.2px; }
     h2 { font-size: var(--font-base); margin: 0 0 10px; color: var(--muted); font-weight: 600; letter-spacing: 0.2px; }


### PR DESCRIPTION
## Summary
- Allow body to scroll with overflow-y auto
- Remove overflow clipping from container and cards

## Testing
- `npm test`
- `node - <<'NODE' ...`

------
https://chatgpt.com/codex/tasks/task_e_68b9de6da9748320a8bf01f2c500adb9