### PR TITLE
Improve budget chart layout and responsiveness

### DIFF
--- a/budget.html
+++ b/budget.html
@@ -145,11 +145,17 @@
           </tbody>
         </table>
         <div class="kpi">
-          <div class="item budget-chart">
+          <div class="item">
             <div class="label">Biudžeto grafikas</div>
-            <canvas id="budgetChart" width="480" height="240"></canvas>
-            <canvas id="dayNightChart" width="480" height="240"></canvas>
-            <canvas id="staffChart" width="480" height="240"></canvas>
+            <canvas id="budgetChart"></canvas>
+          </div>
+          <div class="item">
+            <div class="label">Dienos/Nakties grafikas</div>
+            <canvas id="dayNightChart"></canvas>
+          </div>
+          <div class="item">
+            <div class="label">Darbuotojų grafikas</div>
+            <canvas id="staffChart"></canvas>
           </div>
         </div>
       </div>

--- a/styles.css
+++ b/styles.css
@@ -89,23 +89,16 @@
     .switch input:checked::after { transform: translateX(16px); }
     .switch-block { margin: 10px 0 6px; }
 
-    .kpi { display: grid; gap: 12px; margin-top: 8px; }
-    @media (min-width: 960px) { .kpi { grid-template-columns: repeat(3, minmax(0,1fr)); } }
+    .kpi { display: grid; gap: 12px; margin-top: 8px; grid-template-columns: repeat(auto-fit, minmax(300px, 1fr)); }
     .role-heading { margin-top: 14px; }
     .kpi .item { padding: 12px; border-radius: 14px; border: 1px solid var(--border); background: var(--panel); }
     .kpi .label { font-size: var(--font-xs); color: var(--muted); }
     .kpi .val { font-size: var(--font-lg); font-weight: 700; margin-top: 2px; }
-    .kpi canvas { width: 100%; max-width: 120px; height: 60px !important; margin-top: 8px; }
-    .kpi .pay-chart canvas { max-width: none; height: 160px !important; }
+    .kpi .item canvas { width:100%; height:200px; }
+    .kpi .pay-chart canvas { height:160px; }
     @media (min-width: 960px) { .kpi .pay-chart { grid-column: 1 / -1; } }
-    .kpi .flow-chart canvas { max-width: none; height: 240px !important; }
+    .kpi .flow-chart canvas { height:240px; }
     @media (min-width: 960px) { .kpi .flow-chart { grid-column: 1 / -1; } }
-    .kpi .budget-chart canvas {
-      max-width: none;
-      height: auto !important;
-      aspect-ratio: 2 / 1;
-    }
-    @media (min-width: 960px) { .kpi .budget-chart { grid-column: 1 / -1; } }
     .pill { display:inline-block; padding: 4px 8px; border-radius: 999px; font-size: var(--font-xs); border:1px solid var(--border); background:var(--panel); }
     .accent { color: var(--accent); }
     .muted { color: var(--muted); }


### PR DESCRIPTION
## Summary
- Wrap each budget canvas in its own labeled item for clearer layout
- Make KPI grid responsive and size canvases via CSS

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b9df81ea788320a24728be4ab06b99