### PR TITLE
Fix budget charts growing on scroll

### DIFF
--- a/budget.html
+++ b/budget.html
@@ -170,15 +170,21 @@
         <div class="kpi">
           <div class="item">
             <div class="label">Biudžeto grafikas</div>
-            <canvas id="budgetChart"></canvas>
+            <div class="chart-wrap">
+              <canvas id="budgetChart"></canvas>
+            </div>
           </div>
           <div class="item">
             <div class="label">Dienos/Nakties grafikas</div>
-            <canvas id="dayNightChart"></canvas>
+            <div class="chart-wrap">
+              <canvas id="dayNightChart"></canvas>
+            </div>
           </div>
           <div class="item">
             <div class="label">Darbuotojų grafikas</div>
-            <canvas id="staffChart"></canvas>
+            <div class="chart-wrap">
+              <canvas id="staffChart"></canvas>
+            </div>
           </div>
         </div>
       </div>

--- a/styles.css
+++ b/styles.css
@@ -95,6 +95,8 @@
     .kpi .label { font-size: var(--font-xs); color: var(--muted); }
     .kpi .val { font-size: var(--font-lg); font-weight: 700; margin-top: 2px; }
     .kpi .item canvas { width:100%; height:200px; }
+    .kpi .item .chart-wrap { height:200px; }
+    .kpi .item .chart-wrap canvas { height:100%; }
     .kpi .pay-chart canvas { height:160px; }
     @media (min-width: 960px) { .kpi .pay-chart { grid-column: 1 / -1; } }
     .kpi .flow-chart canvas { height:240px; }


### PR DESCRIPTION
## Summary
- wrap each budget page chart in a padding-free container to stop repeated resizing on scroll
- add `.chart-wrap` styles so canvases fill a fixed-height wrapper

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68ba8a84b4888320ad638912687c40f8