### PR TITLE
Widen results section on budget planner

### DIFF
--- a/budget.html
+++ b/budget.html
@@ -16,7 +16,7 @@
       </label>
     </div>
 
-    <div class="grid grid-2">
+    <div class="grid grid-2 budget-grid">
       <div class="card">
         <h2>Įvestis</h2>
         <div class="row">

--- a/styles.css
+++ b/styles.css
@@ -62,6 +62,8 @@
       overflow: hidden;
     }
     @media (min-width: 960px) { .grid-2 { grid-template-columns: 1.2fr 0.8fr; } }
+    /* Biudžeto planavimo skaičiuoklėje rezultatai turi būti platesni nei įvestis */
+    @media (min-width: 960px) { .budget-grid { grid-template-columns: 0.8fr 1.2fr; } }
     .card {
       background: radial-gradient(1200px 400px at 10% 0%, var(--panel), var(--card));
       border: 1px solid var(--border);


### PR DESCRIPTION
## Summary
- Narrow the input panel and widen results on the budget planner page
- Introduce `.budget-grid` class for budget planner layout

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68ba8c9ce4048320847fb29f2027211a