### PR TITLE
Limit chart height in zone coefficient calculator

### DIFF
--- a/index.html
+++ b/index.html
@@ -163,23 +163,31 @@
           <div class="item">
             <div class="label">Santykis Pacientų skaičius/Zonos talpa</div>
             <div class="val" id="ratio">0.00</div>
-            <canvas id="ratioChart" width="480" height="240"></canvas>
+            <div class="chart-wrap">
+              <canvas id="ratioChart"></canvas>
+            </div>
             <div class="help">Apkrovos intervalas lemia V<sub>priedas</sub></div>
           </div>
           <div class="item">
             <div class="label">Aukštos skubos dalis S = (ESI1+ESI2)/Pacientų skaičius</div>
             <div class="val" id="sShare">0.00</div>
-            <canvas id="sChart" width="480" height="240"></canvas>
+            <div class="chart-wrap">
+              <canvas id="sChart"></canvas>
+            </div>
             <div class="help">Lemia A<sub>priedas</sub></div>
           </div>
-            <div class="item pay-chart">
-              <div class="label">Tarifų grafikas</div>
-              <canvas id="payChart" width="480" height="160"></canvas>
+          <div class="item pay-chart">
+            <div class="label">Tarifų grafikas</div>
+            <div class="chart-wrap">
+              <canvas id="payChart"></canvas>
             </div>
-            <div class="item flow-chart">
-              <div class="label">Pacientų srautas laike</div>
-              <canvas id="flowChart" width="480" height="240"></canvas>
+          </div>
+          <div class="item flow-chart">
+            <div class="label">Pacientų srautas laike</div>
+            <div class="chart-wrap">
+              <canvas id="flowChart"></canvas>
             </div>
+          </div>
           </div>
 
         <table class="table">

--- a/styles.css
+++ b/styles.css
@@ -96,12 +96,11 @@
     .kpi .item { padding: 12px; border-radius: 14px; border: 1px solid var(--border); background: var(--panel); }
     .kpi .label { font-size: var(--font-xs); color: var(--muted); }
     .kpi .val { font-size: var(--font-lg); font-weight: 700; margin-top: 2px; }
-    .kpi .item canvas { width:100%; height:200px; }
     .kpi .item .chart-wrap { height:200px; }
-    .kpi .item .chart-wrap canvas { height:100%; }
-    .kpi .pay-chart canvas { height:160px; }
+    .kpi .item .chart-wrap canvas { width:100%; height:100%; }
+    .kpi .pay-chart .chart-wrap { height:160px; }
     @media (min-width: 960px) { .kpi .pay-chart { grid-column: 1 / -1; } }
-    .kpi .flow-chart canvas { height:240px; }
+    .kpi .flow-chart .chart-wrap { height:240px; }
     @media (min-width: 960px) { .kpi .flow-chart { grid-column: 1 / -1; } }
     .pill { display:inline-block; padding: 4px 8px; border-radius: 999px; font-size: var(--font-xs); border:1px solid var(--border); background:var(--panel); }
     .accent { color: var(--accent); }

--- a/ui.js
+++ b/ui.js
@@ -121,7 +121,7 @@ if (els.ratioCanvas) {
             cutout: '70%',
             plugins: { legend: { display: false }, tooltip: { enabled: false } },
             maintainAspectRatio: false,
-            responsive: false
+            responsive: true
           }
         });
       }
@@ -147,7 +147,7 @@ if (els.sCanvas) {
             plugins: { legend: { display: false } },
             scales: { x: { display: false }, y: { display: false } },
             maintainAspectRatio: false,
-            responsive: false
+            responsive: true
           }
         });
       }


### PR DESCRIPTION
## Summary
- Keep charts from growing vertically by wrapping canvases in fixed-height containers
- Ensure ratio and urgency charts resize with layout

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68bad25fe504832081ad873ad14a1d0e