### PR TITLE
Adjust Budget Planner layout

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -63,7 +63,7 @@
     }
     @media (min-width: 960px) { .grid-2 { grid-template-columns: 1.2fr 0.8fr; } }
     /* Biudžeto planavimo skaičiuoklėje rezultatai turi būti platesni nei įvestis */
-    @media (min-width: 960px) { .budget-grid { grid-template-columns: 0.8fr 1.2fr; } }
+    @media (min-width: 960px) { .budget-grid { grid-template-columns: 0.6fr 1.4fr; } }
     .card {
       background: radial-gradient(1200px 400px at 10% 0%, var(--panel), var(--card));
       border: 1px solid var(--border);


### PR DESCRIPTION
## Summary
- Further shrink input column and expand results column on the budget planner page

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68bad53db15483209287a04168bc2640