### PR TITLE
Add back button to budget planner and rename link

### DIFF
--- a/budget-ui.js
+++ b/budget-ui.js
@@ -99,6 +99,11 @@ const els = {
 
 initThemeToggle();
 
+const goBack = document.getElementById("goBack");
+if (goBack) {
+  goBack.addEventListener("click", (e) => { e.preventDefault(); window.location.href = "index.html"; });
+}
+
 const budgetChart = createBudgetChart(els.budgetChart, 'doughnut');
 const dayNightChart = createDayNightChart(els.dayNightChart);
 const staffChart = createStaffChart(els.staffChart);

--- a/budget.html
+++ b/budget.html
@@ -14,6 +14,7 @@
         <input id="themeToggle" type="checkbox" />
         <span>Šviesi tema</span>
       </label>
+      <button id="goBack" type="button">Grįžti</button>
     </div>
 
     <div class="grid grid-2 budget-grid">

--- a/index.html
+++ b/index.html
@@ -14,7 +14,7 @@
         <input id="themeToggle" type="checkbox" />
         <span>Šviesi tema</span>
       </label>
-      <button id="budgetPlanner" type="button">Biudžeto planuoklis</button>
+      <button id="budgetPlanner" type="button">Biudžeto planavimas</button>
     </div>
 
     <div class="grid grid-2">


### PR DESCRIPTION
## Summary
- Rename "Biudžeto planuoklis" button to "Biudžeto planavimas" on the main calculator page.
- Add a "Grįžti" button to the budget planner page header for easier navigation back to the zone coefficient calculator.
- Wire the new back button to redirect to the main page.

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68badbe2317483208033ebe5d8a25af0