### PR TITLE
Add resizable divider for budget planner

### DIFF
--- a/budget-ui.js
+++ b/budget-ui.js
@@ -260,6 +260,38 @@ function compute(){
   });
 });
 
+const grid = document.querySelector('.budget-grid');
+const resizer = document.querySelector('.resizer');
+if (grid && resizer) {
+  const RESIZER_WIDTH = resizer.getBoundingClientRect().width || 5;
+  let startX = 0;
+  let startLeft = 0;
+
+  function onMouseMove(e){
+    const dx = e.clientX - startX;
+    const total = grid.getBoundingClientRect().width;
+    const newLeft = startLeft + dx;
+    const newRight = total - newLeft - RESIZER_WIDTH;
+    if (newLeft > 0 && newRight > 0){
+      grid.style.gridTemplateColumns = `${newLeft}px ${RESIZER_WIDTH}px ${newRight}px`;
+    }
+  }
+
+  function stop(){
+    document.removeEventListener('mousemove', onMouseMove);
+    document.removeEventListener('mouseup', stop);
+  }
+
+  resizer.addEventListener('mousedown', e => {
+    if (window.innerWidth < 960) return;
+    e.preventDefault();
+    startX = e.clientX;
+    startLeft = grid.children[0].getBoundingClientRect().width;
+    document.addEventListener('mousemove', onMouseMove);
+    document.addEventListener('mouseup', stop);
+  });
+}
+
 loadInputs();
 compute();
 

--- a/budget.html
+++ b/budget.html
@@ -110,11 +110,11 @@
             <input id="countAssistNight" type="number" min="0" step="1" value="0" />
           </div>
         </div>
-        <div class="actions">
+      <div class="actions">
           <a href="index.html">Grįžti</a>
         </div>
       </div>
-
+      <div class="resizer"></div>
       <div class="card">
         <h2>Rezultatai</h2>
         <div class="results-grid">

--- a/styles.css
+++ b/styles.css
@@ -63,7 +63,7 @@
     }
     @media (min-width: 960px) { .grid-2 { grid-template-columns: 1.2fr 0.8fr; } }
     /* Biudžeto planavimo skaičiuoklėje rezultatai turi būti platesni nei įvestis */
-    @media (min-width: 960px) { .budget-grid { grid-template-columns: 0.6fr 1.4fr; } }
+    @media (min-width: 960px) { .budget-grid { grid-template-columns: 0.6fr 5px 1.4fr; } }
     .card {
       background: radial-gradient(1200px 400px at 10% 0%, var(--panel), var(--card));
       border: 1px solid var(--border);
@@ -119,6 +119,8 @@
     .table th { color: var(--muted); font-weight: 600; }
 
     .results-grid { display: grid; gap: 12px; grid-template-columns: repeat(auto-fit, minmax(320px,1fr)); }
+
+    .resizer { width: 5px; background: var(--drag); cursor: col-resize; }
 
 
 


### PR DESCRIPTION
## Summary
- add resizer bar between input and results cards in budget planner
- enable column resizing via mouse drag
- style resizer and adjust grid layout

## Testing
- `npm test --silent >/tmp/unit.log && tail -n 5 /tmp/unit.log`


------
https://chatgpt.com/codex/tasks/task_e_68baf6ebb1288320b183a2ae541dcf9a