### PR TITLE
Add resizer between calculator sections

### DIFF
--- a/index.html
+++ b/index.html
@@ -17,7 +17,7 @@
       <button id="budgetPlanner" type="button">Biudžeto planavimas</button>
     </div>
 
-    <div class="grid grid-2">
+    <div class="grid grid-2 calc-grid">
       <div class="card">
         <h2>Įvestis</h2>
         <div class="row">
@@ -156,7 +156,7 @@
             <button id="downloadPdf">Download PDF</button>
           </div>
       </div>
-
+      <div class="resizer"></div>
       <div class="card">
         <h2>Rezultatai</h2>
         <div class="kpi">

--- a/styles.css
+++ b/styles.css
@@ -62,6 +62,8 @@
       overflow: hidden;
     }
     @media (min-width: 960px) { .grid-2 { grid-template-columns: 1.2fr 0.8fr; } }
+    /* Zoninio koeficiento skaičiuoklėje slankiojimo juosta tarp dalių */
+    @media (min-width: 960px) { .calc-grid { grid-template-columns: 1.2fr 5px 0.8fr; } }
     /* Biudžeto planavimo skaičiuoklėje rezultatai turi būti platesni nei įvestis */
     @media (min-width: 960px) { .budget-grid { grid-template-columns: 0.6fr 5px 1.4fr; } }
     .card {

--- a/ui.js
+++ b/ui.js
@@ -424,6 +424,38 @@ if (els.budgetPlanner) {
   els.budgetPlanner.addEventListener('click', (e)=>{ e.preventDefault(); window.location.href = 'budget.html'; });
 }
 
+const grid = document.querySelector('.calc-grid');
+const resizer = document.querySelector('.resizer');
+if (grid && resizer) {
+  const RESIZER_WIDTH = resizer.getBoundingClientRect().width || 5;
+  let startX = 0;
+  let startLeft = 0;
+
+  function onMouseMove(e){
+    const dx = e.clientX - startX;
+    const total = grid.getBoundingClientRect().width;
+    const newLeft = startLeft + dx;
+    const newRight = total - newLeft - RESIZER_WIDTH;
+    if (newLeft > 0 && newRight > 0){
+      grid.style.gridTemplateColumns = `${newLeft}px ${RESIZER_WIDTH}px ${newRight}px`;
+    }
+  }
+
+  function stop(){
+    document.removeEventListener('mousemove', onMouseMove);
+    document.removeEventListener('mouseup', stop);
+  }
+
+  resizer.addEventListener('mousedown', e => {
+    if (window.innerWidth < 960) return;
+    e.preventDefault();
+    startX = e.clientX;
+    startLeft = grid.children[0].getBoundingClientRect().width;
+    document.addEventListener('mousemove', onMouseMove);
+    document.addEventListener('mouseup', stop);
+  });
+}
+
 renderZoneSelect(false);
 resetAll();
 


### PR DESCRIPTION
## Summary
- add draggable resizer to Zone Coefficient calculator layout
- wire up splitter logic in UI script
- style grid to include resizer and split columns

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68bb15995d788320bba568bfca08d3ad