### PR TITLE
feat: apply saved theme class before loading styles

### DIFF
--- a/budget.html
+++ b/budget.html
@@ -4,6 +4,17 @@
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1" />
   <title>Biudžeto Planavimo Skaičiuoklė</title>
+  <script>
+    (() => {
+      try {
+        if (localStorage.getItem('ED_THEME') === 'light') {
+          document.documentElement.classList.add('light-theme');
+        }
+      } catch (e) {
+        // localStorage might be unavailable
+      }
+    })();
+  </script>
   <link rel="stylesheet" href="styles.css">
 </head>
 <body>

--- a/index.html
+++ b/index.html
@@ -4,6 +4,17 @@
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1" />
   <title>Zoninio Koeficiento Skaičiuoklė (V2 – triažas + apkrova)</title>
+  <script>
+    (() => {
+      try {
+        if (localStorage.getItem('ED_THEME') === 'light') {
+          document.documentElement.classList.add('light-theme');
+        }
+      } catch (e) {
+        // localStorage might be unavailable
+      }
+    })();
+  </script>
   <link rel="stylesheet" href="styles.css">
   </head>
 <body>

--- a/theme.js
+++ b/theme.js
@@ -2,19 +2,29 @@ export function initThemeToggle() {
   const THEME_KEY = 'ED_THEME';
   const root = document.documentElement;
   const body = document.body;
-  const savedTheme = localStorage.getItem(THEME_KEY);
-  if (savedTheme === 'light') {
-    root.classList.add('light-theme');
-    body.classList.add('light-theme');
+
+  let isLight = root.classList.contains('light-theme');
+  if (!isLight) {
+    const savedTheme = localStorage.getItem(THEME_KEY);
+    if (savedTheme === 'light') {
+      root.classList.add('light-theme');
+      isLight = true;
+    }
   }
+  body.classList.toggle('light-theme', isLight);
+
+  // Preload color utilities without blocking init
+  import('@material/material-color-utilities').catch(() => {});
+
   const toggle = document.getElementById('themeToggle');
   if (toggle) {
-    toggle.checked = root.classList.contains('light-theme');
+    toggle.checked = isLight;
     toggle.addEventListener('change', () => {
-      const isLight = toggle.checked;
-      root.classList.toggle('light-theme', isLight);
-      body.classList.toggle('light-theme', isLight);
-      localStorage.setItem(THEME_KEY, isLight ? 'light' : 'dark');
+      const isLightNow = toggle.checked;
+      root.classList.toggle('light-theme', isLightNow);
+      body.classList.toggle('light-theme', isLightNow);
+      localStorage.setItem(THEME_KEY, isLightNow ? 'light' : 'dark');
+      import('@material/material-color-utilities').catch(() => {});
     });
   }
 }


### PR DESCRIPTION
## Summary
- preload `light-theme` class via inline head script based on stored preference
- initialize theme toggle without waiting on async `@material/material-color-utilities` import when class already applied

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68bb1bce82d48320a11b3bd8fdbf8b40