### PR TITLE
Ensure results tables stack vertically

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -120,7 +120,7 @@
     .table th, .table td { padding: 8px 10px; border-bottom: 1px solid var(--border); text-align: left; }
     .table th { color: var(--muted); font-weight: 600; }
 
-    .results-grid { display: grid; gap: 12px; grid-template-columns: repeat(auto-fit, minmax(320px,1fr)); }
+    .results-grid { display: grid; gap: 12px; grid-template-columns: 1fr; overflow-x: auto; }
 
     .resizer { width: 5px; background: var(--drag); cursor: col-resize; }
 


### PR DESCRIPTION
## Summary
- force `.results-grid` to use a single column and add horizontal scroll overflow for wide tables

## Testing
- `node - <<'NODE'
const fs=require('fs');
const {JSDOM,VirtualConsole}=require('jsdom');
const html=fs.readFileSync('budget.html','utf8');
const css=fs.readFileSync('styles.css','utf8');
const vc=new VirtualConsole();
vc.on('error',()=>{});
const dom=new JSDOM(html,{resources:'usable',runScripts:'outside-only',virtualConsole:vc});
const {window}=dom;
const styleEl=window.document.createElement('style');
styleEl.textContent=css;
window.document.head.appendChild(styleEl);
console.log(window.getComputedStyle(window.document.querySelector('.results-grid')).gridTemplateColumns);
NODE`
- `npm test >/tmp/unit.log 2>&1 && tail -n 20 /tmp/unit.log`

------
https://chatgpt.com/codex/tasks/task_e_68bb2394aef08320b7095e85080a3a0c