### PR TITLE
Add input validation and styling for calculators

### DIFF
--- a/budget-ui.js
+++ b/budget-ui.js
@@ -115,6 +115,26 @@ const INPUT_IDS = [
 ];
 const STORAGE_KEY = 'budgetInputs';
 
+function validateInputs(){
+  INPUT_IDS.forEach(id => {
+    const el = els[id];
+    if (!el) return;
+    const val = toNum(el.value);
+    if (val < 0) {
+      el.classList.add('input-error');
+      el.classList.remove('input-warning');
+      el.title = 'Reikšmė negali būti neigiama';
+    } else if (id === 'maxCoefficient' && (val < 1 || val > 2)) {
+      el.classList.add('input-warning');
+      el.classList.remove('input-error');
+      el.title = 'Leistinas intervalas 1–2';
+    } else {
+      el.classList.remove('input-error','input-warning');
+      el.removeAttribute('title');
+    }
+  });
+}
+
 function loadInputs(){
   if (typeof localStorage === 'undefined') return;
   try{
@@ -137,6 +157,7 @@ function saveInputs(){
 }
 
 function compute(){
+  validateInputs();
   const docDay = toNum(els.countDocDay.value);
   const docNight = toNum(els.countDocNight.value);
   const nurseDay = toNum(els.countNurseDay.value);

--- a/styles.css
+++ b/styles.css
@@ -6,6 +6,7 @@
       --accent: #22c55e;    /* green-500 */
       --accent-2: #60a5fa;  /* blue-400 */
       --danger: #ef4444;    /* red-500 */
+      --warning: #eab308;   /* amber-500 */
       --card: #0b1220;      /* custom */
       --border: #1f2937;    /* gray-800 */
       --drag: #334155;      /* slate-600 */
@@ -25,6 +26,7 @@
       --accent: #16a34a;    /* green-600 */
       --accent-2: #2563eb;  /* blue-600 */
       --danger: #dc2626;    /* red-600 */
+      --warning: #d97706;   /* amber-600 */
       --card: #ffffff;      /* white */
       --border: #e2e8f0;    /* slate-200 */
       --drag: #cbd5e1;      /* slate-300 */
@@ -81,6 +83,8 @@
       background: var(--panel); color: var(--text); outline: none; transition: border-color .2s;
     }
     input[type="number"]:focus, input[type="date"]:focus, input[type="text"]:focus, select:focus { border-color: var(--accent-2); }
+    .input-error { border-color: var(--danger) !important; }
+    .input-warning { border-color: var(--warning) !important; }
     .row { display: grid; grid-template-columns: 1fr 1fr; gap: 12px; }
     .row-3 { display: grid; grid-template-columns: 1fr 1fr 1fr; gap: 12px; }
     .zone-row { grid-template-columns: 1fr auto; gap: 8px; }

--- a/ui.js
+++ b/ui.js
@@ -231,8 +231,28 @@ function toNum(v){ const n = Number(v); return Number.isFinite(n) ? n : 0; }
 function fmt(n, d=2){ return (Number.isFinite(n) ? n : 0).toFixed(d); }
 function money(n){ try{ return new Intl.NumberFormat('lt-LT',{style:'currency',currency:'EUR'}).format(n||0); }catch{ return `€${fmt(n)}`; } }
 
+function validateInputs(){
+  ['zoneCapacity','patientCount','maxCoefficient','shiftHours','monthHours','baseRateDoc','baseRateNurse','baseRateAssist','esi1','esi2','esi3','esi4','esi5'].forEach(id => {
+    const el = els[id];
+    if (!el) return;
+    const val = toNum(el.value);
+    if (val < 0) {
+      el.classList.add('input-error');
+      el.classList.remove('input-warning');
+      el.title = 'Reikšmė negali būti neigiama';
+    } else if (id === 'maxCoefficient' && (val < 1 || val > 2)) {
+      el.classList.add('input-warning');
+      el.classList.remove('input-error');
+      el.title = 'Leistinas intervalas 1–2';
+    } else {
+      el.classList.remove('input-error','input-warning');
+      el.removeAttribute('title');
+    }
+  });
+}
 
 function compute(){
+  validateInputs();
   const zoneCapacity = Math.max(0, toNum(els.zoneCapacity.value));
   const maxCoefficient = Math.min(2, Math.max(1, toNum(els.maxCoefficient.value)));
   const baseDoc = Math.max(0, toNum(els.baseRateDoc.value));


### PR DESCRIPTION
## Summary
- highlight invalid form inputs using new `.input-error` and `.input-warning` styles
- validate calculator inputs for negative numbers and out-of-range coefficients
- provide tooltip messages for invalid values

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68bbe1c185988320ad8203d65e8616e3