### PR TITLE
Fallback to ESI counts when patient count missing

### DIFF
--- a/compute.js
+++ b/compute.js
@@ -52,9 +52,8 @@ function compute({
   const sN3 = sanitize(n3);
   const sN4 = sanitize(n4);
   const sN5 = sanitize(n5);
-  const totalN = Number.isFinite(patientCount ?? N)
-    ? Math.max(0, patientCount ?? N)
-    : sN1 + sN2 + sN3 + sN4 + sN5;
+  const providedN = sanitize(patientCount ?? N);
+  const totalN = providedN > 0 ? providedN : sN1 + sN2 + sN3 + sN4 + sN5;
   const ratio = c > 0 ? totalN / c : 0;
   const V = getBonus(ratio, THRESHOLDS.V_BONUS);
   const high = sN1 + sN2;

--- a/tests/budget-ui.test.js
+++ b/tests/budget-ui.test.js
@@ -136,3 +136,52 @@ test('updates bonus fields with computed values', () => {
   expect(parse(document.getElementById('shiftBonusTotal').textContent)).toBeCloseTo(expected.shift_bonus.total);
   expect(parse(document.getElementById('monthBonusTotal').textContent)).toBeCloseTo(expected.month_bonus.total);
 });
+
+test('uses ESI counts when patientCount is zero', () => {
+  setupDOM();
+  const { compute } = require('../budget-ui.js');
+  const { computeBudget } = require('../budget.js');
+
+  document.getElementById('shiftHours').value = '12';
+  document.getElementById('monthHours').value = '160';
+  document.getElementById('baseRateDoc').value = '10';
+  document.getElementById('baseRateNurse').value = '8';
+  document.getElementById('baseRateAssist').value = '6';
+  document.getElementById('countDocDay').value = '1';
+  document.getElementById('zoneCapacity').value = '80';
+  document.getElementById('patientCount').value = '0';
+  document.getElementById('maxCoefficient').value = '1.3';
+  document.getElementById('n1').value = '10';
+  document.getElementById('n2').value = '20';
+  document.getElementById('n3').value = '70';
+  document.getElementById('n4').value = '0';
+  document.getElementById('n5').value = '0';
+
+  compute();
+
+  const expected = computeBudget({
+    counts: {
+      day: { doctor: 1, nurse: 0, assistant: 0 },
+      night: { doctor: 0, nurse: 0, assistant: 0 },
+    },
+    rateInputs: {
+      zoneCapacity: 80,
+      patientCount: 0,
+      maxCoefficient: 1.3,
+      baseDoc: 10,
+      baseNurse: 8,
+      baseAssist: 6,
+      shiftH: 12,
+      monthH: 160,
+      n1: 10,
+      n2: 20,
+      n3: 70,
+      n4: 0,
+      n5: 0,
+    }
+  });
+
+  const parse = s => Number(s.replace(/[^0-9,-]/g, '').replace(',', '.'));
+  expect(parse(document.getElementById('docRate').textContent)).toBeCloseTo(expected.final_rates.doctor);
+  expect(parse(document.getElementById('shiftBonusTotal').textContent)).toBeGreaterThan(0);
+});

--- a/tests/compute.test.js
+++ b/tests/compute.test.js
@@ -43,6 +43,28 @@ describe('compute core logic', () => {
     expect(result.K_zona).toBeCloseTo(1.20);
   });
 
+  test('falls back to ESI counts when patientCount is zero', () => {
+    const result = compute({
+      zoneCapacity: 80,
+      patientCount: 0,
+      maxCoefficient: 1.3,
+      baseDoc: 10,
+      baseNurse: 10,
+      baseAssist: 10,
+      shiftH: 0,
+      monthH: 0,
+      n1: 10,
+      n2: 20,
+      n3: 70,
+      n4: 0,
+      n5: 0,
+    });
+    expect(result.patientCount).toBe(100);
+    expect(result.V_bonus).toBeGreaterThan(0);
+    expect(result.A_bonus).toBeGreaterThan(0);
+    expect(result.K_zona).toBeGreaterThan(1);
+  });
+
   test('bonuses capped by kMax', () => {
     const result = compute({
       zoneCapacity: 80,


### PR DESCRIPTION
## Summary
- Use sum of ESI levels when patientCount is zero or not provided
- Test compute() behavior for missing patientCount
- Verify budget UI computes bonuses using ESI fallback

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68bbf910d9388320b900960db1d2798b