### PR TITLE
feat: enforce minimum staffing levels

### DIFF
--- a/src/optimizer.js
+++ b/src/optimizer.js
@@ -1,13 +1,27 @@
-export function suggestStaffing({ zoneCapacity = 0, budgetLimit = Infinity, rates = {} }) {
+/**
+ * Suggest a staffing configuration for a zone.
+ *
+ * @param {Object} options
+ * @param {number} [options.zoneCapacity=0] - Number of staff required for the zone.
+ * @param {number} [options.budgetLimit=Infinity] - Maximum allowed cost.
+ * @param {Object} [options.rates={}] - Hourly rates for each role.
+ * @param {Object} [options.min={}] - Minimum number of each role to include.
+ * @returns {{day:Object, night:Object}} Suggested staffing for day and night shifts.
+ */
+export function suggestStaffing({ zoneCapacity = 0, budgetLimit = Infinity, rates = {}, min = {} }) {
   const required = Math.max(0, Math.ceil(Number(zoneCapacity)));
   const rateDoc = Number(rates.doctor) || 0;
   const rateNurse = Number(rates.nurse) || 0;
   const rateAssist = Number(rates.assistant) || 0;
+  const minDoc = Number(min.doctor) || 0;
+  const minNurse = Number(min.nurse) || 0;
+  const minAssist = Number(min.assistant) || 0;
   let best = null;
-  const max = required; // max count per role to search
-  for (let d = 0; d <= max; d++) {
-    for (let n = 0; n <= max; n++) {
-      for (let a = 0; a <= max; a++) {
+  const max = Math.max(required, minDoc, minNurse, minAssist); // max count per role to search
+  for (let d = minDoc; d <= max; d++) {
+    for (let n = minNurse; n <= max; n++) {
+      for (let a = minAssist; a <= max; a++) {
+        if (d < minDoc || n < minNurse || a < minAssist) continue;
         const coverage = d + n + a;
         if (coverage < required) continue;
         const cost = d * rateDoc + n * rateNurse + a * rateAssist;
@@ -20,7 +34,12 @@ export function suggestStaffing({ zoneCapacity = 0, budgetLimit = Infinity, rate
   }
   if (!best) {
     // No feasible solution within budget; return minimal coverage ignoring budget
-    best = { d: 0, n: 0, a: 0, cost: 0 };
+    best = {
+      d: minDoc,
+      n: minNurse,
+      a: minAssist,
+      cost: minDoc * rateDoc + minNurse * rateNurse + minAssist * rateAssist,
+    };
   }
   const suggestion = {
     day: { doctor: best.d, nurse: best.n, assistant: best.a },

--- a/tests/optimizer.test.js
+++ b/tests/optimizer.test.js
@@ -19,4 +19,15 @@ describe('suggestStaffing', () => {
     });
     expect(result.day).toEqual({ doctor: 3, nurse: 0, assistant: 0 });
   });
+
+  test('respects minimum staffing levels even if more expensive', () => {
+    const result = suggestStaffing({
+      zoneCapacity: 2,
+      budgetLimit: 1000,
+      rates: { doctor: 100, nurse: 50, assistant: 20 },
+      min: { doctor: 1, nurse: 1, assistant: 0 },
+    });
+    expect(result.day).toEqual({ doctor: 1, nurse: 1, assistant: 0 });
+    expect(result.night).toEqual({ doctor: 1, nurse: 1, assistant: 0 });
+  });
 });


### PR DESCRIPTION
## Summary
- allow suggestStaffing to accept minimum counts per role
- skip configurations below min values and return min staffing when no affordable solution
- test respecting minimum staffing even when cheaper roles exist

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68bc1d397ac08320a8bc9d052e777a85