### PR TITLE
Add minimum staffing constraints to optimizer

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,8 @@
 
 Taip pat galite įvesti pamainos trukmę ir mėnesio valandų skaičių, kad pamatytumėte numatomą uždarbį už pamainą ar mėnesį.
 
+Biudžeto planavimo įrankyje galima nurodyti minimalų gydytojų, slaugytojų ir padėjėjų skaičių. Šios reikšmės (`minDoctor`, `minNurse`, `minAssistant`) naudojamos optimizacijos metu, kad siūlomas personalo skaičius niekada nenukristų žemiau nustatytų ribų.
+
 ## Vykdymas vietoje
 
 1. Nuklonuokite arba atsisiųskite saugyklą.

--- a/budget-ui.js
+++ b/budget-ui.js
@@ -27,6 +27,9 @@ const els = {
   countNurseNight: document.getElementById('countNurseNight'),
   countAssistDay: document.getElementById('countAssistDay'),
   countAssistNight: document.getElementById('countAssistNight'),
+  minDoctor: document.getElementById('minDoctor'),
+  minNurse: document.getElementById('minNurse'),
+  minAssistant: document.getElementById('minAssistant'),
   zoneCapacity: document.getElementById('zoneCapacity'),
   patientCount: document.getElementById('patientCount'),
   maxCoefficient: document.getElementById('maxCoefficient'),
@@ -112,7 +115,8 @@ const staffChart = createStaffChart(els.staffChart);
 const INPUT_IDS = [
   'shiftHours','monthHours','baseRateDoc','baseRateNurse','baseRateAssist',
   'countDocDay','countDocNight','countNurseDay','countNurseNight','countAssistDay','countAssistNight',
-  'zoneCapacity','patientCount','maxCoefficient','n1','n2','n3','n4','n5'
+  'zoneCapacity','patientCount','maxCoefficient','n1','n2','n3','n4','n5',
+  'minDoctor','minNurse','minAssistant'
 ];
 const STORAGE_KEY = 'budgetInputs';
 
@@ -173,6 +177,9 @@ function compute(optimize = false){
   const n3 = toNum(els.n3?.value);
   const n4 = toNum(els.n4?.value);
   const n5 = toNum(els.n5?.value);
+  const minDoc = toNum(els.minDoctor?.value);
+  const minNurse = toNum(els.minNurse?.value);
+  const minAssist = toNum(els.minAssistant?.value);
 
   const counts = {
     day: {
@@ -203,6 +210,7 @@ function compute(optimize = false){
       n3,
       n4,
       n5,
+      min: { doctor: minDoc, nurse: minNurse, assistant: minAssist },
     },
     optimize,
   });

--- a/budget.html
+++ b/budget.html
@@ -121,6 +121,20 @@
             <input id="countAssistNight" type="number" min="0" step="1" value="0" />
           </div>
         </div>
+        <div class="row-3">
+          <div>
+            <label for="minDoctor">Min. gydytojų skaičius</label>
+            <input id="minDoctor" type="number" min="0" step="1" value="0" />
+          </div>
+          <div>
+            <label for="minNurse">Min. slaugytojų skaičius</label>
+            <input id="minNurse" type="number" min="0" step="1" value="0" />
+          </div>
+          <div>
+            <label for="minAssistant">Min. padėjėjų skaičius</label>
+            <input id="minAssistant" type="number" min="0" step="1" value="0" />
+          </div>
+        </div>
         <div class="actions">
           <button id="optimizeStaff" type="button">Optimize Staffing</button>
         </div>

--- a/budget.js
+++ b/budget.js
@@ -16,6 +16,7 @@ export function computeBudget({ counts = {}, rateInputs = {}, nightMultiplier = 
       zoneCapacity: rateInputs.zoneCapacity,
       budgetLimit: rateInputs.budgetLimit,
       rates: salaryData.shift_salary,
+      min: rateInputs.min,
     });
     usedCounts = recommendation;
   }

--- a/index.html
+++ b/index.html
@@ -110,6 +110,21 @@
           </div>
         </div>
 
+        <div class="row-3">
+          <div>
+            <label for="minDoctor">Min. gydytojų skaičius</label>
+            <input id="minDoctor" type="number" min="0" step="1" value="0" />
+          </div>
+          <div>
+            <label for="minNurse">Min. slaugytojų skaičius</label>
+            <input id="minNurse" type="number" min="0" step="1" value="0" />
+          </div>
+          <div>
+            <label for="minAssistant">Min. padėjėjų skaičius</label>
+            <input id="minAssistant" type="number" min="0" step="1" value="0" />
+          </div>
+        </div>
+
         <div class="switch-block">
           <label class="switch">
             <input id="linkPatientCount" type="checkbox" checked />

--- a/tests/budget-ui.test.js
+++ b/tests/budget-ui.test.js
@@ -14,7 +14,8 @@ jest.mock('../chart-utils.js', () => {
 const inputIds = [
   'shiftHours','monthHours','baseRateDoc','baseRateNurse','baseRateAssist',
   'countDocDay','countDocNight','countNurseDay','countNurseNight','countAssistDay','countAssistNight',
-  'zoneCapacity','patientCount','maxCoefficient','n1','n2','n3','n4','n5'
+  'zoneCapacity','patientCount','maxCoefficient','n1','n2','n3','n4','n5',
+  'minDoctor','minNurse','minAssistant'
 ];
 const cellIds = [
   'docDayCount','docNightCount','nurseDayCount','nurseNightCount','assistDayCount','assistNightCount',


### PR DESCRIPTION
## Summary
- add minDoctor/minNurse/minAssistant inputs to forms
- capture new minimums in UI and forward as `rateInputs.min`
- pass minimum staffing into `suggestStaffing` during optimization
- document minimum staffing support

## Testing
- `npm test` *(fails: command not found: npm)*
- `apt-get install -y nodejs npm` *(fails: Unable to locate package nodejs)*

------
https://chatgpt.com/codex/tasks/task_e_68bc3df0e1b88320aba99be59f37600d