### PR TITLE
Group budget inputs by section

### DIFF
--- a/budget.html
+++ b/budget.html
@@ -31,110 +31,122 @@
     <div class="grid grid-2 budget-grid">
       <div class="card">
         <h2>Įvestis</h2>
-        <div class="row">
-          <div>
-            <label for="shiftHours">Pamainos trukmė (val.)</label>
-            <input id="shiftHours" type="number" min="0" step="0.5" value="12" />
+        <fieldset class="section">
+          <legend>Pamainos parametrai</legend>
+          <div class="row">
+            <div>
+              <label for="shiftHours">Pamainos trukmė (val.)</label>
+              <input id="shiftHours" type="number" min="0" step="0.5" value="12" />
+            </div>
+            <div>
+              <label for="monthHours">Mėnesio valandos</label>
+              <input id="monthHours" type="number" min="0" step="0.5" value="160" />
+            </div>
           </div>
-          <div>
-            <label for="monthHours">Mėnesio valandos</label>
-            <input id="monthHours" type="number" min="0" step="0.5" value="160" />
+        </fieldset>
+        <fieldset class="section">
+          <legend>Pacientų pasiskirstymas</legend>
+          <div class="row-3">
+            <div>
+              <label for="zoneCapacity">Zonos talpa</label>
+              <input id="zoneCapacity" type="number" min="0" step="1" value="1" />
+            </div>
+            <div>
+              <label for="patientCount">Pacientų skaičius</label>
+              <input id="patientCount" type="number" min="0" step="1" value="0" />
+            </div>
+            <div>
+              <label for="maxCoefficient">Maksimalus koeficientas</label>
+              <input id="maxCoefficient" type="number" min="0" step="0.01" value="1" />
+            </div>
           </div>
-        </div>
-        <div class="row-3">
-          <div>
-            <label for="zoneCapacity">Zonos talpa</label>
-            <input id="zoneCapacity" type="number" min="0" step="1" value="1" />
+          <div class="row-3">
+            <div>
+              <label for="n1">ESI 1</label>
+              <input id="n1" type="number" min="0" step="1" value="0" />
+            </div>
+            <div>
+              <label for="n2">ESI 2</label>
+              <input id="n2" type="number" min="0" step="1" value="0" />
+            </div>
+            <div>
+              <label for="n3">ESI 3</label>
+              <input id="n3" type="number" min="0" step="1" value="0" />
+            </div>
           </div>
-          <div>
-            <label for="patientCount">Pacientų skaičius</label>
-            <input id="patientCount" type="number" min="0" step="1" value="0" />
+          <div class="row">
+            <div>
+              <label for="n4">ESI 4</label>
+              <input id="n4" type="number" min="0" step="1" value="0" />
+            </div>
+            <div>
+              <label for="n5">ESI 5</label>
+              <input id="n5" type="number" min="0" step="1" value="0" />
+            </div>
           </div>
-          <div>
-            <label for="maxCoefficient">Maksimalus koeficientas</label>
-            <input id="maxCoefficient" type="number" min="0" step="0.01" value="1" />
+        </fieldset>
+        <fieldset class="section">
+          <legend>Darbuotojai</legend>
+          <div class="row-3">
+            <div>
+              <label for="baseRateDoc">Bazinis gydytojo tarifas (€ / val.)</label>
+              <input id="baseRateDoc" type="number" min="0" step="0.01" value="0" placeholder="pvz. 25.00" />
+            </div>
+            <div>
+              <label for="countDocDay">Gydytojų (dieną)</label>
+              <input id="countDocDay" type="number" min="0" step="1" value="0" />
+            </div>
+            <div>
+              <label for="countDocNight">Gydytojų (naktį)</label>
+              <input id="countDocNight" type="number" min="0" step="1" value="0" />
+            </div>
           </div>
-        </div>
-        <div class="row-3">
-          <div>
-            <label for="n1">ESI 1</label>
-            <input id="n1" type="number" min="0" step="1" value="0" />
+          <div class="row-3">
+            <div>
+              <label for="baseRateNurse">Bazinis slaugytojo tarifas (€ / val.)</label>
+              <input id="baseRateNurse" type="number" min="0" step="0.01" value="0" placeholder="pvz. 14.00" />
+            </div>
+            <div>
+              <label for="countNurseDay">Slaugytojų (dieną)</label>
+              <input id="countNurseDay" type="number" min="0" step="1" value="0" />
+            </div>
+            <div>
+              <label for="countNurseNight">Slaugytojų (naktį)</label>
+              <input id="countNurseNight" type="number" min="0" step="1" value="0" />
+            </div>
           </div>
-          <div>
-            <label for="n2">ESI 2</label>
-            <input id="n2" type="number" min="0" step="1" value="0" />
+          <div class="row-3">
+            <div>
+              <label for="baseRateAssist">Bazinis padėjėjo tarifas (€ / val.)</label>
+              <input id="baseRateAssist" type="number" min="0" step="0.01" value="0" placeholder="pvz. 9.00" />
+            </div>
+            <div>
+              <label for="countAssistDay">Padėjėjų (dieną)</label>
+              <input id="countAssistDay" type="number" min="0" step="1" value="0" />
+            </div>
+            <div>
+              <label for="countAssistNight">Padėjėjų (naktį)</label>
+              <input id="countAssistNight" type="number" min="0" step="1" value="0" />
+            </div>
           </div>
-          <div>
-            <label for="n3">ESI 3</label>
-            <input id="n3" type="number" min="0" step="1" value="0" />
+        </fieldset>
+        <fieldset class="section">
+          <legend>Minimalūs normatyvai</legend>
+          <div class="row-3">
+            <div>
+              <label for="minDoctor">Min. gydytojų skaičius</label>
+              <input id="minDoctor" type="number" min="0" step="1" value="0" />
+            </div>
+            <div>
+              <label for="minNurse">Min. slaugytojų skaičius</label>
+              <input id="minNurse" type="number" min="0" step="1" value="0" />
+            </div>
+            <div>
+              <label for="minAssistant">Min. padėjėjų skaičius</label>
+              <input id="minAssistant" type="number" min="0" step="1" value="0" />
+            </div>
           </div>
-        </div>
-        <div class="row">
-          <div>
-            <label for="n4">ESI 4</label>
-            <input id="n4" type="number" min="0" step="1" value="0" />
-          </div>
-          <div>
-            <label for="n5">ESI 5</label>
-            <input id="n5" type="number" min="0" step="1" value="0" />
-          </div>
-        </div>
-        <div class="row-3">
-          <div>
-            <label for="baseRateDoc">Bazinis gydytojo tarifas (€ / val.)</label>
-            <input id="baseRateDoc" type="number" min="0" step="0.01" value="0" placeholder="pvz. 25.00" />
-          </div>
-          <div>
-            <label for="countDocDay">Gydytojų (dieną)</label>
-            <input id="countDocDay" type="number" min="0" step="1" value="0" />
-          </div>
-          <div>
-            <label for="countDocNight">Gydytojų (naktį)</label>
-            <input id="countDocNight" type="number" min="0" step="1" value="0" />
-          </div>
-        </div>
-        <div class="row-3">
-          <div>
-            <label for="baseRateNurse">Bazinis slaugytojo tarifas (€ / val.)</label>
-            <input id="baseRateNurse" type="number" min="0" step="0.01" value="0" placeholder="pvz. 14.00" />
-          </div>
-          <div>
-            <label for="countNurseDay">Slaugytojų (dieną)</label>
-            <input id="countNurseDay" type="number" min="0" step="1" value="0" />
-          </div>
-          <div>
-            <label for="countNurseNight">Slaugytojų (naktį)</label>
-            <input id="countNurseNight" type="number" min="0" step="1" value="0" />
-          </div>
-        </div>
-        <div class="row-3">
-          <div>
-            <label for="baseRateAssist">Bazinis padėjėjo tarifas (€ / val.)</label>
-            <input id="baseRateAssist" type="number" min="0" step="0.01" value="0" placeholder="pvz. 9.00" />
-          </div>
-          <div>
-            <label for="countAssistDay">Padėjėjų (dieną)</label>
-            <input id="countAssistDay" type="number" min="0" step="1" value="0" />
-          </div>
-          <div>
-            <label for="countAssistNight">Padėjėjų (naktį)</label>
-            <input id="countAssistNight" type="number" min="0" step="1" value="0" />
-          </div>
-        </div>
-        <div class="row-3">
-          <div>
-            <label for="minDoctor">Min. gydytojų skaičius</label>
-            <input id="minDoctor" type="number" min="0" step="1" value="0" />
-          </div>
-          <div>
-            <label for="minNurse">Min. slaugytojų skaičius</label>
-            <input id="minNurse" type="number" min="0" step="1" value="0" />
-          </div>
-          <div>
-            <label for="minAssistant">Min. padėjėjų skaičius</label>
-            <input id="minAssistant" type="number" min="0" step="1" value="0" />
-          </div>
-        </div>
+        </fieldset>
         <div class="actions">
           <button id="optimizeStaff" type="button">Optimize Staffing</button>
         </div>

--- a/styles.css
+++ b/styles.css
@@ -87,6 +87,8 @@
     .input-warning { border-color: var(--warning) !important; }
     .row { display: grid; grid-template-columns: 1fr 1fr; gap: 12px; }
     .row-3 { display: grid; grid-template-columns: 1fr 1fr 1fr; gap: 12px; }
+    .section { margin: 14px 0; padding: 12px; border: 1px solid var(--border); border-radius: 12px; }
+    legend { font-size: var(--font-base); font-weight: 600; color: var(--accent-2); padding: 0 6px; }
     .zone-row { grid-template-columns: 1fr auto; gap: 8px; }
     .help { font-size: var(--font-xs); color: var(--muted); margin-top: 6px; }
     .switch { display: inline-flex; align-items: center; gap: 8px; user-select: none; cursor: pointer; font-size: var(--font-sm); color: var(--muted); }


### PR DESCRIPTION
## Summary
- Group related budget inputs under fieldset sections with legends
- Add CSS for `.section` and `legend` to give each group spacing and hierarchy

## Testing
- `npm test 2>&1 | tail -n 15`

------
https://chatgpt.com/codex/tasks/task_e_68bc517b099083208cc2e1279d0dc878