### PR TITLE
Organize staff groups and style in budget planner

### DIFF
--- a/budget.html
+++ b/budget.html
@@ -81,51 +81,67 @@
             </div>
           </div>
         </fieldset>
-        <fieldset class="section">
-          <legend>Darbuotojai</legend>
-          <div class="row-3">
-            <div>
-              <label for="baseRateDoc">Bazinis gydytojo tarifas (€ / val.)</label>
-              <input id="baseRateDoc" type="number" min="0" step="0.01" value="0" placeholder="pvz. 25.00" />
+          <fieldset class="section">
+            <legend>Darbuotojai</legend>
+
+            <div class="staff-group">
+              <h3>Gydytojas</h3>
+              <div class="row-3">
+                <div>
+                  <label for="baseRateDoc">Bazinis gydytojo tarifas (€ / val.)</label>
+                  <input id="baseRateDoc" type="number" min="0" step="0.01" value="0" placeholder="pvz. 25.00" />
+                </div>
+                <div>
+                  <label for="countDocDay">Gydytojų (dieną)</label>
+                  <input id="countDocDay" type="number" min="0" step="1" value="0" />
+                </div>
+                <div>
+                  <label for="countDocNight">Gydytojų (naktį)</label>
+                  <input id="countDocNight" type="number" min="0" step="1" value="0" />
+                </div>
+              </div>
             </div>
-            <div>
-              <label for="countDocDay">Gydytojų (dieną)</label>
-              <input id="countDocDay" type="number" min="0" step="1" value="0" />
+
+            <div class="staff-group">
+              <h3>Slaugytojas</h3>
+              <div class="row-3">
+                <div>
+                  <label for="baseRateNurse">Bazinis slaugytojo tarifas (€ / val.)</label>
+                  <input id="baseRateNurse" type="number" min="0" step="0.01" value="0" placeholder="pvz. 14.00" />
+                </div>
+                <div>
+                  <label for="countNurseDay">Slaugytojų (dieną)</label>
+                  <input id="countNurseDay" type="number" min="0" step="1" value="0" />
+                </div>
+                <div>
+                  <label for="countNurseNight">Slaugytojų (naktį)</label>
+                  <input id="countNurseNight" type="number" min="0" step="1" value="0" />
+                </div>
+              </div>
             </div>
-            <div>
-              <label for="countDocNight">Gydytojų (naktį)</label>
-              <input id="countDocNight" type="number" min="0" step="1" value="0" />
+
+            <div class="staff-group">
+              <h3>Padėjėjas</h3>
+              <div class="row-3">
+                <div>
+                  <label for="baseRateAssist">Bazinis padėjėjo tarifas (€ / val.)</label>
+                  <input id="baseRateAssist" type="number" min="0" step="0.01" value="0" placeholder="pvz. 9.00" />
+                </div>
+                <div>
+                  <label for="countAssistDay">Padėjėjų (dieną)</label>
+                  <input id="countAssistDay" type="number" min="0" step="1" value="0" />
+                </div>
+                <div>
+                  <label for="countAssistNight">Padėjėjų (naktį)</label>
+                  <input id="countAssistNight" type="number" min="0" step="1" value="0" />
+                </div>
+              </div>
             </div>
-          </div>
-          <div class="row-3">
-            <div>
-              <label for="baseRateNurse">Bazinis slaugytojo tarifas (€ / val.)</label>
-              <input id="baseRateNurse" type="number" min="0" step="0.01" value="0" placeholder="pvz. 14.00" />
+
+            <div class="actions">
+              <button id="optimizeStaff" type="button">Optimize Staffing</button>
             </div>
-            <div>
-              <label for="countNurseDay">Slaugytojų (dieną)</label>
-              <input id="countNurseDay" type="number" min="0" step="1" value="0" />
-            </div>
-            <div>
-              <label for="countNurseNight">Slaugytojų (naktį)</label>
-              <input id="countNurseNight" type="number" min="0" step="1" value="0" />
-            </div>
-          </div>
-          <div class="row-3">
-            <div>
-              <label for="baseRateAssist">Bazinis padėjėjo tarifas (€ / val.)</label>
-              <input id="baseRateAssist" type="number" min="0" step="0.01" value="0" placeholder="pvz. 9.00" />
-            </div>
-            <div>
-              <label for="countAssistDay">Padėjėjų (dieną)</label>
-              <input id="countAssistDay" type="number" min="0" step="1" value="0" />
-            </div>
-            <div>
-              <label for="countAssistNight">Padėjėjų (naktį)</label>
-              <input id="countAssistNight" type="number" min="0" step="1" value="0" />
-            </div>
-          </div>
-        </fieldset>
+          </fieldset>
         <details class="section">
           <summary>Išplėstinės parinktys</summary>
           <div class="row">
@@ -149,9 +165,6 @@
             </div>
           </div>
         </details>
-        <div class="actions">
-          <button id="optimizeStaff" type="button">Optimize Staffing</button>
-        </div>
       </div>
       <div class="resizer"></div>
       <div class="card">

--- a/styles.css
+++ b/styles.css
@@ -88,6 +88,8 @@
     .row { display: grid; grid-template-columns: 1fr 1fr; gap: 12px; }
     .row-3 { display: grid; grid-template-columns: 1fr 1fr 1fr; gap: 12px; }
     .section { margin: 14px 0; padding: 12px; border: 1px solid var(--border); border-radius: 12px; }
+    .staff-group { margin-top: 12px; padding: 12px; border: 1px solid var(--border); border-radius: 12px; }
+    .staff-group h3 { margin: 0 0 8px; font-size: var(--font-base); color: var(--accent-2); font-weight: 600; }
     legend { font-size: var(--font-base); font-weight: 600; color: var(--accent-2); padding: 0 6px; }
     details { margin: 14px 0; padding: 12px; border: 1px solid var(--border); border-radius: 12px; }
     summary { cursor: pointer; font-size: var(--font-base); font-weight: 600; color: var(--accent-2); padding: 0 6px; }


### PR DESCRIPTION
## Summary
- Wrap each staff role in `budget.html` into its own `.staff-group` with headers and three-column layout
- Add `.staff-group` CSS for borders, spacing, and colored headings
- Relocate "Optimize Staffing" button to the bottom of the staff section

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68bc5401b4448320bdb0f67ff3a0269f