### PR TITLE
Respect OS theme preference

### DIFF
--- a/budget.html
+++ b/budget.html
@@ -7,8 +7,15 @@
   <script>
     (() => {
       try {
-        if (localStorage.getItem('ED_THEME') === 'light') {
-          document.documentElement.classList.add('light-theme');
+        const root = document.documentElement;
+        const prefersLight =
+          window.matchMedia &&
+          window.matchMedia('(prefers-color-scheme: light)').matches;
+        const saved = localStorage.getItem('ED_THEME');
+        if (prefersLight && !saved) {
+          root.classList.add('light-theme');
+        } else if (saved === 'light') {
+          root.classList.add('light-theme');
         }
       } catch (e) {
         // localStorage might be unavailable

--- a/index.html
+++ b/index.html
@@ -7,8 +7,15 @@
   <script>
     (() => {
       try {
-        if (localStorage.getItem('ED_THEME') === 'light') {
-          document.documentElement.classList.add('light-theme');
+        const root = document.documentElement;
+        const prefersLight =
+          window.matchMedia &&
+          window.matchMedia('(prefers-color-scheme: light)').matches;
+        const saved = localStorage.getItem('ED_THEME');
+        if (prefersLight && !saved) {
+          root.classList.add('light-theme');
+        } else if (saved === 'light') {
+          root.classList.add('light-theme');
         }
       } catch (e) {
         // localStorage might be unavailable

--- a/tests/theme.test.js
+++ b/tests/theme.test.js
@@ -1,5 +1,13 @@
 const { initThemeToggle } = require('../theme.js');
 
+beforeEach(() => {
+  document.documentElement.className = '';
+  document.body.className = '';
+  document.body.innerHTML = '';
+  localStorage.clear();
+  delete window.matchMedia;
+});
+
 test('initThemeToggle toggles theme', () => {
   document.body.innerHTML = '<input id="themeToggle" type="checkbox" />';
   localStorage.setItem('ED_THEME', 'light');
@@ -10,4 +18,18 @@ test('initThemeToggle toggles theme', () => {
   toggle.dispatchEvent(new Event('change'));
   expect(document.documentElement.classList.contains('light-theme')).toBe(false);
   expect(localStorage.getItem('ED_THEME')).toBe('dark');
+});
+
+test('applies light theme when OS prefers light and no saved theme', () => {
+  window.matchMedia = jest.fn().mockReturnValue({ matches: true });
+  initThemeToggle();
+  expect(document.documentElement.classList.contains('light-theme')).toBe(true);
+  expect(document.body.classList.contains('light-theme')).toBe(true);
+});
+
+test('keeps dark theme when OS prefers dark and no saved theme', () => {
+  window.matchMedia = jest.fn().mockReturnValue({ matches: false });
+  initThemeToggle();
+  expect(document.documentElement.classList.contains('light-theme')).toBe(false);
+  expect(document.body.classList.contains('light-theme')).toBe(false);
 });

--- a/theme.js
+++ b/theme.js
@@ -5,8 +5,14 @@ export function initThemeToggle() {
 
   let isLight = root.classList.contains('light-theme');
   if (!isLight) {
+    const prefersLight =
+      window.matchMedia &&
+      window.matchMedia('(prefers-color-scheme: light)').matches;
     const savedTheme = localStorage.getItem(THEME_KEY);
-    if (savedTheme === 'light') {
+    if (prefersLight && !savedTheme) {
+      root.classList.add('light-theme');
+      isLight = true;
+    } else if (savedTheme === 'light') {
       root.classList.add('light-theme');
       isLight = true;
     }


### PR DESCRIPTION
## Summary
- Apply light theme by default when the OS prefers light and no theme is saved
- Update index and budget pages to initialize the theme using the same logic
- Add tests covering OS-based theme selection without localStorage

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68bc5c71fc548320ac5b44f82ebfc9a2