### PR TITLE
Organize zone calculator inputs into grouped sections

### DIFF
--- a/index.html
+++ b/index.html
@@ -38,137 +38,153 @@
     <div class="grid grid-2 calc-grid">
       <div class="card">
         <h2>Įvestis</h2>
-        <div class="row">
-          <div>
-            <label for="date">Data</label>
-            <input id="date" type="date" />
-          </div>
-          <div>
-            <label for="shift">Pamaina</label>
-            <select id="shift">
-              <option value="D">Dieninė</option>
-              <option value="N">Naktinė</option>
-              <option value="P">Paros</option>
-            </select>
-          </div>
-        </div>
-        <div class="row">
-          <div>
-            <label for="zone">Zona</label>
-            <div class="row zone-row">
-              <select id="zone"></select>
-              <button id="manageZones" type="button">Tvarkyti zonas</button>
+        <nav class="nav-sections">
+          <a href="#shift-section">Pamainos parametrai</a>
+          <a href="#patients-section">Pacientų pasiskirstymas</a>
+          <a href="#rates-section">Tarifai</a>
+          <a href="#advanced-section">Išplėstinės parinktys</a>
+        </nav>
+        <fieldset id="shift-section" class="section">
+          <legend>Pamainos parametrai</legend>
+          <div class="row">
+            <div>
+              <label for="date">Data</label>
+              <input id="date" type="date" />
+            </div>
+            <div>
+              <label for="shift">Pamaina</label>
+              <select id="shift">
+                <option value="D">Dieninė</option>
+                <option value="N">Naktinė</option>
+                <option value="P">Paros</option>
+              </select>
             </div>
           </div>
-          <div>
-            <label for="zoneCapacity">Zonos talpa (pac./pam.)</label>
-            <input id="zoneCapacity" type="number" min="0" step="1" placeholder="pvz. 16" />
-            <div class="help">Keičiant zoną/pamainą įstatoma numatytoji talpa (galite perrašyti).</div>
-            <!-- formerly id="capacity" representing C -->
-          </div>
-        </div>
-
-        <div class="row">
-          <div>
-            <label for="patientCount">Pacientų skaičius (zonoje per pamainą)</label>
-            <input id="patientCount" type="number" min="0" step="1" value="0" />
-            <!-- formerly id="N" -->
-          </div>
-          <div>
-            <label for="maxCoefficient">Maksimalus koeficientas</label>
-            <input id="maxCoefficient" type="number" min="1" max="2" step="0.01" value="1.30" />
-            <!-- formerly id="kmax" -->
-          </div>
-        </div>
-
-        <div class="row">
-          <div>
-            <label for="shiftHours">Pamainos trukmė (val.)</label>
-            <input id="shiftHours" type="number" min="0" step="0.5" value="12" />
-          </div>
-          <div>
-            <label for="monthHours">Mėnesio valandos</label>
-            <input id="monthHours" type="number" min="0" step="0.5" value="0" />
-          </div>
-        </div>
-
-        <div class="row">
-          <div>
-            <label for="baseRateDoc">Bazinis gydytojo tarifas (€ / val.)</label>
-            <input id="baseRateDoc" type="number" min="0" step="0.01" value="0" placeholder="pvz. 25.00" />
-          </div>
-          <div>
-            <label for="baseRateNurse">Bazinis slaugytojo tarifas (€ / val.)</label>
-            <input id="baseRateNurse" type="number" min="0" step="0.01" value="0" placeholder="pvz. 14.00" />
-          </div>
-        </div>
-        <div class="row">
-          <div>
-            <label for="baseRateAssist">Bazinis padėjėjo tarifas (€ / val.)</label>
-            <input id="baseRateAssist" type="number" min="0" step="0.01" value="0" placeholder="pvz. 9.00" />
-          </div>
-          <div>
-            <label>&nbsp;</label>
-            <div class="actions">
-              <button id="saveRateTemplate">Įsiminti tarifų šabloną</button>
-              <button id="loadRateTemplate">Užkrauti šabloną</button>
+          <div class="row">
+            <div>
+              <label for="zone">Zona</label>
+              <div class="row zone-row">
+                <select id="zone"></select>
+                <button id="manageZones" type="button">Tvarkyti zonas</button>
+              </div>
             </div>
-            <div class="help">Tarifų šablonas saugomas vietoje (localStorage).</div>
+            <div>
+              <label for="zoneCapacity">Zonos talpa (pac./pam.)</label>
+              <input id="zoneCapacity" type="number" min="0" step="1" placeholder="pvz. 16" />
+              <div class="help">Keičiant zoną/pamainą įstatoma numatytoji talpa (galite perrašyti).</div>
+              <!-- formerly id="capacity" representing C -->
+            </div>
           </div>
-        </div>
+          <div class="row">
+            <div>
+              <label for="shiftHours">Pamainos trukmė (val.)</label>
+              <input id="shiftHours" type="number" min="0" step="0.5" value="12" />
+            </div>
+            <div>
+              <label for="monthHours">Mėnesio valandos</label>
+              <input id="monthHours" type="number" min="0" step="0.5" value="0" />
+            </div>
+          </div>
+        </fieldset>
 
-        <div class="row-3">
-          <div>
-            <label for="minDoctor">Min. gydytojų skaičius</label>
-            <input id="minDoctor" type="number" min="0" step="1" value="0" />
+        <fieldset id="patients-section" class="section">
+          <legend>Pacientų pasiskirstymas</legend>
+          <div class="row">
+            <div>
+              <label for="patientCount">Pacientų skaičius (zonoje per pamainą)</label>
+              <input id="patientCount" type="number" min="0" step="1" value="0" />
+              <!-- formerly id="N" -->
+            </div>
           </div>
-          <div>
-            <label for="minNurse">Min. slaugytojų skaičius</label>
-            <input id="minNurse" type="number" min="0" step="1" value="0" />
+          <div class="switch-block">
+            <label class="switch">
+              <input id="linkPatientCount" type="checkbox" checked />
+              <span>Naudoti Pacientų skaičių = ESI1+ESI2+ESI3+ESI4+ESI5</span>
+              <!-- formerly id="linkN" -->
+            </label>
           </div>
-          <div>
-            <label for="minAssistant">Min. padėjėjų skaičius</label>
-            <input id="minAssistant" type="number" min="0" step="1" value="0" />
+          <div class="row-3">
+            <div>
+              <label for="esi1">ESI-1</label>
+              <input id="esi1" type="number" min="0" step="1" value="0" />
+            </div>
+            <div>
+              <label for="esi2">ESI-2</label>
+              <input id="esi2" type="number" min="0" step="1" value="0" />
+            </div>
+            <div>
+              <label for="esi3">ESI-3</label>
+              <input id="esi3" type="number" min="0" step="1" value="0" />
+            </div>
           </div>
-        </div>
+          <div class="row-3">
+            <div>
+              <label for="esi4">ESI-4</label>
+              <input id="esi4" type="number" min="0" step="1" value="0" />
+            </div>
+            <div>
+              <label for="esi5">ESI-5</label>
+              <input id="esi5" type="number" min="0" step="1" value="0" />
+            </div>
+            <div>
+              <label>&nbsp;</label>
+              <div class="help">Jei nėra triažo – palikite visur nulį.</div>
+            </div>
+          </div>
+        </fieldset>
 
-        <div class="switch-block">
-          <label class="switch">
-            <input id="linkPatientCount" type="checkbox" checked />
-            <span>Naudoti Pacientų skaičių = ESI1+ESI2+ESI3+ESI4+ESI5</span>
-            <!-- formerly id="linkN" -->
-          </label>
-        </div>
+        <fieldset id="rates-section" class="section">
+          <legend>Tarifai</legend>
+          <div class="row">
+            <div>
+              <label for="baseRateDoc">Bazinis gydytojo tarifas (€ / val.)</label>
+              <input id="baseRateDoc" type="number" min="0" step="0.01" value="0" placeholder="pvz. 25.00" />
+            </div>
+            <div>
+              <label for="baseRateNurse">Bazinis slaugytojo tarifas (€ / val.)</label>
+              <input id="baseRateNurse" type="number" min="0" step="0.01" value="0" placeholder="pvz. 14.00" />
+            </div>
+          </div>
+          <div class="row">
+            <div>
+              <label for="baseRateAssist">Bazinis padėjėjo tarifas (€ / val.)</label>
+              <input id="baseRateAssist" type="number" min="0" step="0.01" value="0" placeholder="pvz. 9.00" />
+            </div>
+            <div>
+              <label>&nbsp;</label>
+              <div class="actions">
+                <button id="saveRateTemplate">Įsiminti tarifų šabloną</button>
+                <button id="loadRateTemplate">Užkrauti šabloną</button>
+              </div>
+              <div class="help">Tarifų šablonas saugomas vietoje (localStorage).</div>
+            </div>
+          </div>
+        </fieldset>
 
-        <div class="row-3">
-          <div>
-            <label for="esi1">ESI-1</label>
-            <input id="esi1" type="number" min="0" step="1" value="0" />
+        <details id="advanced-section" class="section">
+          <summary>Išplėstinės parinktys</summary>
+          <div class="row">
+            <div>
+              <label for="maxCoefficient">Maksimalus koeficientas</label>
+              <input id="maxCoefficient" type="number" min="1" max="2" step="0.01" value="1.30" />
+              <!-- formerly id="kmax" -->
+            </div>
           </div>
-          <div>
-            <label for="esi2">ESI-2</label>
-            <input id="esi2" type="number" min="0" step="1" value="0" />
+          <div class="row-3">
+            <div>
+              <label for="minDoctor">Min. gydytojų skaičius</label>
+              <input id="minDoctor" type="number" min="0" step="1" value="0" />
+            </div>
+            <div>
+              <label for="minNurse">Min. slaugytojų skaičius</label>
+              <input id="minNurse" type="number" min="0" step="1" value="0" />
+            </div>
+            <div>
+              <label for="minAssistant">Min. padėjėjų skaičius</label>
+              <input id="minAssistant" type="number" min="0" step="1" value="0" />
+            </div>
           </div>
-          <div>
-            <label for="esi3">ESI-3</label>
-            <input id="esi3" type="number" min="0" step="1" value="0" />
-          </div>
-        </div>
-        <div class="row-3">
-          <div>
-            <label for="esi4">ESI-4</label>
-            <input id="esi4" type="number" min="0" step="1" value="0" />
-          </div>
-          <div>
-            <label for="esi5">ESI-5</label>
-            <input id="esi5" type="number" min="0" step="1" value="0" />
-          </div>
-          <div>
-            <label>&nbsp;</label>
-            <div class="help">Jei nėra triažo – palikite visur nulį.</div>
-          </div>
-          </div>
-
+        </details>
 
         <div class="row">
           <div>
@@ -181,13 +197,13 @@
           </div>
         </div>
 
-          <div class="actions">
-            <button id="simulateEsi">Simuliuoti pamainą</button>
-            <button class="primary" id="reset">Išvalyti</button>
-            <button id="copy">Kopijuoti rezultatą (JSON)</button>
-            <button id="downloadCsv">Download CSV</button>
-            <button id="downloadPdf">Download PDF</button>
-          </div>
+        <div class="actions">
+          <button id="simulateEsi">Simuliuoti pamainą</button>
+          <button class="primary" id="reset">Išvalyti</button>
+          <button id="copy">Kopijuoti rezultatą (JSON)</button>
+          <button id="downloadCsv">Download CSV</button>
+          <button id="downloadPdf">Download PDF</button>
+        </div>
       </div>
       <div class="resizer"></div>
       <div class="card">


### PR DESCRIPTION
## Summary
- Group Zoninio Koeficiento Skaičiuoklė inputs into logical sections with navigation like the budget planner
- Add separate fieldsets for shift parameters, patient distribution, rates, and advanced options

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68bc671742c883209175b7a9b7665bda