### PR TITLE
Add safe chart creation helper

### DIFF
--- a/src/chart/utils.js
+++ b/src/chart/utils.js
@@ -1,0 +1,21 @@
+export function safeCreateChart(canvas, config, name) {
+  if (!canvas || typeof Chart === 'undefined') return null;
+  try {
+    const ctx = canvas.getContext && canvas.getContext('2d');
+    if (!ctx) return null;
+    return new Chart(ctx, config);
+  } catch (err) {
+    const id = canvas && canvas.id ? `#${canvas.id}` : '';
+    console.error(`Failed to create ${name} chart (${id})`, err?.stack || err);
+    const msg = document.createElement('div');
+    msg.className = 'chart-error';
+    msg.textContent = `Unable to render ${name} chart`;
+    canvas.replaceWith(msg);
+    return null;
+  }
+}
+
+// CommonJS compatibility for tests
+if (typeof module !== 'undefined') {
+  module.exports = { safeCreateChart };
+}


### PR DESCRIPTION
## Summary
- add `safeCreateChart` utility to centralize Chart.js creation with error handling
- simplify UI by replacing try/catch blocks with `safeCreateChart`

## Testing
- `npm test`
- `npm run lint` *(fails: ESLint couldn't find an eslint.config.* file)*

------
https://chatgpt.com/codex/tasks/task_e_68bd078845f08320b3a9efdcf2a50e10