### PR TITLE
docs: annotate public functions

### DIFF
--- a/compute.js
+++ b/compute.js
@@ -24,6 +24,54 @@ function sanitize(value) {
   return Number.isFinite(value) ? Math.max(0, value) : 0;
 }
 
+/**
+ * @typedef {Object} RateSet
+ * @property {number} doctor   Hourly rate for doctors.
+ * @property {number} nurse    Hourly rate for nurses.
+ * @property {number} assistant Hourly rate for assistants.
+ */
+
+/**
+ * @typedef {Object} ComputeResult
+ * @property {number} patientCount Total number of patients.
+ * @property {{n1:number,n2:number,n3:number,n4:number,n5:number}} ESI Counts for each ESI level.
+ * @property {number} ratio Patient to capacity ratio.
+ * @property {number} S Proportion of high-acuity patients (ESI 1–2).
+ * @property {number} V_bonus Volume bonus coefficient.
+ * @property {number} A_bonus Acuity bonus coefficient.
+ * @property {number} maxCoefficient Maximum allowed coefficient.
+ * @property {number} K_zona Final zone coefficient.
+ * @property {number} shift_hours Hours in a shift.
+ * @property {number} month_hours Hours in a month.
+ * @property {RateSet} base_rates Base hourly wages.
+ * @property {RateSet} baseline_shift_salary Baseline salary per shift.
+ * @property {RateSet} baseline_month_salary Baseline salary per month.
+ * @property {RateSet} final_rates Adjusted hourly wages.
+ * @property {RateSet} shift_salary Adjusted salary per shift.
+ * @property {RateSet} month_salary Adjusted salary per month.
+ */
+
+/**
+ * Calculates adjusted salaries and related statistics for a zone.
+ * @param {Object} params Configuration parameters.
+ * @param {number} [params.zoneCapacity] Maximum number of patients the zone can handle.
+ * @param {number} [params.maxCoefficient] Upper limit for the zone coefficient.
+ * @param {number} params.baseDoc Base hourly wage for doctors.
+ * @param {number} params.baseNurse Base hourly wage for nurses.
+ * @param {number} params.baseAssist Base hourly wage for assistants.
+ * @param {number} params.shiftH Number of hours in a shift.
+ * @param {number} params.monthH Number of hours in a month.
+ * @param {number} params.n1 Number of ESI level 1 patients.
+ * @param {number} params.n2 Number of ESI level 2 patients.
+ * @param {number} params.n3 Number of ESI level 3 patients.
+ * @param {number} params.n4 Number of ESI level 4 patients.
+ * @param {number} params.n5 Number of ESI level 5 patients.
+ * @param {number} [params.patientCount] Total number of patients. If omitted, sum of ESI counts is used.
+ * @param {number} [params.C] Legacy zone capacity input.
+ * @param {number} [params.kMax] Legacy max coefficient input.
+ * @param {number} [params.N] Legacy patient count input.
+ * @returns {ComputeResult} Detailed computation results.
+ */
 function compute({
   zoneCapacity,
   maxCoefficient,

--- a/downloads.js
+++ b/downloads.js
@@ -1,3 +1,10 @@
+/** @typedef {import('./compute.js').ComputeResult} ComputeResult */
+
+/**
+ * Builds a CSV string summarizing computed salaries.
+ * @param {ComputeResult & {date:string,shift:string,zone:string,zone_label:string,zoneCapacity:number}} data Data to encode.
+ * @returns {string} CSV formatted string.
+ */
 export function buildCsv(data) {
   const rows = [
     ['date', data.date],
@@ -35,6 +42,10 @@ export function buildCsv(data) {
   return csvUtils.rowsToCsv(rows);
 }
 
+/**
+ * Initiates download of a CSV file containing computation results.
+ * @param {ComputeResult & {date:string,shift:string,zone:string,zone_label:string,zoneCapacity:number}} data Data to export.
+ */
 export function downloadCsv(data) {
   const csv = buildCsv(data);
   const blob = new Blob([csv], { type: 'text/csv' });
@@ -48,6 +59,11 @@ export function downloadCsv(data) {
   URL.revokeObjectURL(url);
 }
 
+/**
+ * Builds a PDF document with optional charts.
+ * @param {ComputeResult & Record<string, any>} data Data for the report.
+ * @returns {import('jspdf').jsPDF} Generated PDF document.
+ */
 export function buildPdf(data) {
   const chartImages = {};
   if (typeof document !== 'undefined' && typeof Chart !== 'undefined') {
@@ -93,6 +109,10 @@ export function buildPdf(data) {
   return pdfUtils.generatePdf(data, chartImages);
 }
 
+/**
+ * Creates and downloads a PDF report.
+ * @param {ComputeResult & Record<string, any>} data Data for the report.
+ */
 export function downloadPdf(data) {
   try {
     const doc = buildPdf(data);

--- a/jsconfig.json
+++ b/jsconfig.json
@@ -1,0 +1,7 @@
+{
+  "compilerOptions": {
+    "checkJs": true,
+    "target": "ES2019"
+  },
+  "exclude": ["node_modules"]
+}

--- a/simulation.js
+++ b/simulation.js
@@ -6,6 +6,13 @@ function createRng(seed) {
   };
 }
 
+/**
+ * Generates a random distribution of patients among ESI levels.
+ * @param {number} patientCount Total number of patients. If non-positive, a value is generated from zone capacity.
+ * @param {number} zoneCapacity Capacity of the zone used when estimating patient count.
+ * @param {number|Function} [seed] Seed value or RNG function.
+ * @returns {{total:number, counts:number[]}} Total patients and counts for ESI levels 1-5.
+ */
 function simulateEsiCounts(patientCount, zoneCapacity, seed) {
   const rng = typeof seed === 'function' ? seed : seed !== undefined ? createRng(seed) : Math.random;
   let total = Math.floor(Number(patientCount));
@@ -43,6 +50,19 @@ try {
   }
 } catch {}
 
+/**
+ * Simulates patient flow over multiple days.
+ * @param {number} days Number of days to simulate.
+ * @param {number} zoneCapacity Capacity of the zone.
+ * @param {Object} [options] Simulation options.
+ * @param {number[]} [options.patientCounts=DAILY_PATIENT_COUNTS] Baseline patient counts for a week.
+ * @param {number} [options.variation=0] Random variation factor applied to counts.
+ * @param {number} [options.startIndex=0] Starting index within patientCounts.
+ * @param {boolean} [options.useForecast=false] Whether to use forecast model if available.
+ * @param {number|Function} [seed] Seed value or RNG function.
+ * @returns {{days:Array<{day:number,total:number,counts:number[]}>, summary:{totalPatients:number,esiTotals:number[]}}}
+ *          Simulated daily results and overall summary.
+ */
 function simulatePeriod(days, zoneCapacity, options = {}, seed) {
   const {
     patientCounts = DAILY_PATIENT_COUNTS,

--- a/zones.js
+++ b/zones.js
@@ -7,12 +7,27 @@ export const DEFAULT_ZONES = [
 
 const LS_KEY = 'ED_ZONES_V2';
 
+/**
+ * Deep copies a value using JSON serialization.
+ * @param {any} obj Value to clone.
+ * @returns {any} Cloned value.
+ */
 export function clone(obj) { return JSON.parse(JSON.stringify(obj)); }
+
+/**
+ * Normalizes arbitrary text into a safe zone identifier.
+ * @param {string} txt Raw text entered by the user.
+ * @returns {string} Sanitized identifier consisting of A-Z, 0-9 and underscores.
+ */
 export function sanitizeId(txt) {
   const s = (txt || '').toString().toUpperCase().replace(/[^A-Z0-9]+/g, '_').replace(/^_|_$/g, '');
   return s || 'ZONE_' + Math.random().toString(36).slice(2,6).toUpperCase();
 }
 
+/**
+ * Loads zone definitions from local storage.
+ * @returns {Array<object>} Array of zone objects.
+ */
 export function loadZones() {
   try {
     const j = localStorage.getItem(LS_KEY);
@@ -27,6 +42,10 @@ export function loadZones() {
   return clone(DEFAULT_ZONES);
 }
 
+/**
+ * Persists zone definitions to local storage.
+ * @param {Array<object>} zs Zones to save.
+ */
 export function saveZones(zs) {
   try {
     localStorage.setItem(LS_KEY, JSON.stringify(zs));
@@ -36,6 +55,11 @@ export function saveZones(zs) {
   }
 }
 
+/**
+ * Initializes zone management UI.
+ * @param {Object} els Map of DOM elements used for zone management.
+ * @returns {Object} Utilities for interacting with the zone UI.
+ */
 export function initZones(els) {
   let ZONES = loadZones();
 


### PR DESCRIPTION
## Summary
- add comprehensive JSDoc to `compute` and other public APIs
- document exports in zones, downloads, and simulation modules
- add `jsconfig.json` for IDE type hints

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68bd0fae48088320b3f0e5de19b92b1f