### PR TITLE
Implement multi-step form navigation with progress tracking

### DIFF
--- a/index.html
+++ b/index.html
@@ -44,6 +44,8 @@
           <a href="#rates-section">Tarifai</a>
           <a href="#advanced-section">Išplėstinės parinktys</a>
         </nav>
+        <div class="progress"><div id="stepProgressBar" class="bar"></div></div>
+        <div class="step active" data-step="1">
         <fieldset id="shift-section" class="section">
           <legend>Pamainos parametrai</legend>
           <div class="row">
@@ -86,7 +88,12 @@
             </div>
           </div>
         </fieldset>
+        <div class="step-nav actions">
+          <button type="button" class="next-step">Next</button>
+        </div>
+        </div>
 
+        <div class="step" data-step="2">
         <fieldset id="patients-section" class="section">
           <legend>Pacientų pasiskirstymas</legend>
           <div class="row">
@@ -132,7 +139,13 @@
             </div>
           </div>
         </fieldset>
+        <div class="step-nav actions">
+          <button type="button" class="back-step">Back</button>
+          <button type="button" class="next-step">Next</button>
+        </div>
+        </div>
 
+        <div class="step" data-step="3">
         <fieldset id="rates-section" class="section">
           <legend>Tarifai</legend>
           <div class="row">
@@ -160,7 +173,13 @@
             </div>
           </div>
         </fieldset>
+        <div class="step-nav actions">
+          <button type="button" class="back-step">Back</button>
+          <button type="button" class="next-step">Next</button>
+        </div>
+        </div>
 
+        <div class="step" data-step="4">
         <details id="advanced-section" class="section">
           <summary>Išplėstinės parinktys</summary>
           <div class="row">
@@ -204,6 +223,10 @@
           <button id="copy">Kopijuoti rezultatą (JSON)</button>
           <button id="downloadCsv">Download CSV</button>
           <button id="downloadPdf">Download PDF</button>
+        </div>
+        <div class="step-nav actions">
+          <button type="button" class="back-step">Back</button>
+        </div>
         </div>
       </div>
       <div class="resizer"></div>

--- a/styles.css
+++ b/styles.css
@@ -69,9 +69,14 @@
       white-space: nowrap;
     }
     .nav-sections a:hover { background: var(--card); border-color: var(--accent-2); }
+    .nav-sections a.active { background: var(--accent); color: #fff; }
     @media (max-width: 600px) {
       .nav-sections { overflow-x: auto; flex-wrap: nowrap; -webkit-overflow-scrolling: touch; }
     }
+    .step { display: none; }
+    .step.active { display: block; }
+    .progress { height: 4px; background: var(--border); margin: 10px 0; }
+    .progress .bar { height: 100%; width: 0; background: var(--accent); transition: width 0.3s; }
     .grid {
       display: grid;
       gap: 14px;

--- a/ui.js
+++ b/ui.js
@@ -468,6 +468,93 @@ if (els.budgetPlanner) {
   els.budgetPlanner.addEventListener('click', (e)=>{ e.preventDefault(); window.location.href = 'budget.html'; });
 }
 
+// Step management
+const stepEls = Array.from(document.querySelectorAll('.step'));
+const navLinks = Array.from(document.querySelectorAll('.nav-sections a'));
+const progressBar = document.getElementById('stepProgressBar');
+let currentStep = 0;
+
+function updateProgress(){
+  navLinks.forEach(link => {
+    const target = document.querySelector(link.getAttribute('href'));
+    const idx = stepEls.findIndex(step => step.contains(target));
+    link.classList.toggle('active', idx === currentStep);
+  });
+  if (progressBar) {
+    progressBar.style.width = `${((currentStep + 1) / stepEls.length) * 100}%`;
+  }
+}
+
+function showStep(i){
+  stepEls.forEach((el, idx) => {
+    el.classList.toggle('active', idx === i);
+  });
+  currentStep = i;
+  updateProgress();
+}
+
+function validateStep(i){
+  const step = stepEls[i];
+  const inputs = step.querySelectorAll('input, select, textarea');
+  for (const input of inputs){
+    if (!input.reportValidity()) return false;
+  }
+  return true;
+}
+
+function stepFromHash(hash){
+  const id = hash.replace('#','');
+  const target = document.getElementById(id);
+  return stepEls.findIndex(step => step.contains(target));
+}
+
+function goToHash(){
+  const idx = stepFromHash(location.hash);
+  if (idx >= 0) {
+    showStep(idx);
+  } else {
+    showStep(0);
+  }
+}
+
+window.addEventListener('hashchange', goToHash);
+
+stepEls.forEach((step, idx) => {
+  const next = step.querySelector('.next-step');
+  const back = step.querySelector('.back-step');
+  if (next) {
+    next.addEventListener('click', () => {
+      if (!validateStep(idx)) return;
+      const ni = Math.min(idx + 1, stepEls.length - 1);
+      showStep(ni);
+      const anchor = stepEls[ni].querySelector('[id]')?.id;
+      if (anchor) history.replaceState(null, '', `#${anchor}`);
+    });
+  }
+  if (back) {
+    back.addEventListener('click', () => {
+      const pi = Math.max(idx - 1, 0);
+      showStep(pi);
+      const anchor = stepEls[pi].querySelector('[id]')?.id;
+      if (anchor) history.replaceState(null, '', `#${anchor}`);
+    });
+  }
+});
+
+navLinks.forEach(link => {
+  link.addEventListener('click', e => {
+    e.preventDefault();
+    const hash = link.getAttribute('href');
+    const idx = stepFromHash(hash);
+    if (idx >= 0) {
+      showStep(idx);
+      history.replaceState(null, '', hash);
+    }
+  });
+});
+
+goToHash();
+
 const grid = document.querySelector('.calc-grid');
 const resizer = document.querySelector('.resizer');
 if (grid && resizer) {


### PR DESCRIPTION
## Summary
- Group input sections into step containers with forward/back buttons
- Track progress and highlight active step in navigation
- Manage steps via JavaScript, including validation and deep-link support

## Testing
- `npm test`
- `npm run lint` *(fails: 'expect' is not defined, Parsing error: 'import' and 'export' may appear only with 'sourceType: module')*


------
https://chatgpt.com/codex/tasks/task_e_68bdbe3e3f908320a79c335e4b572206