### PR TITLE
Normalize ESI keys when loading budget planner inputs

### DIFF
--- a/budget-ui.js
+++ b/budget-ui.js
@@ -268,9 +268,20 @@ function loadInputs(){
   if (typeof localStorage === 'undefined') return;
   try{
     const saved = JSON.parse(localStorage.getItem(STORAGE_KEY)) || {};
+
+    for (let i = 1; i <= 5; i++) {
+      const nKey = `n${i}`;
+      const esiKey = `esi${i}`;
+      if (saved[nKey] === undefined && saved[esiKey] !== undefined) {
+        saved[nKey] = saved[esiKey];
+      }
+    }
+
     INPUT_IDS.forEach(id => {
       if (els[id] && saved[id] !== undefined) els[id].value = saved[id];
     });
+
+    localStorage.setItem(STORAGE_KEY, JSON.stringify(saved));
   }catch{}
 }
 

--- a/tests/budget-ui.test.js
+++ b/tests/budget-ui.test.js
@@ -56,6 +56,20 @@ test('loads saved values from localStorage', () => {
   expect(document.getElementById('zoneCapacity').value).toBe('3');
 });
 
+test('maps esi keys to n keys when loading', () => {
+  setupDOM();
+  localStorage.setItem(
+    'budgetInputs',
+    JSON.stringify({ esi1: '1', esi2: '2', esi3: '3', esi4: '4', esi5: '5' })
+  );
+  require('../budget-ui.js');
+  expect(document.getElementById('n1').value).toBe('1');
+  expect(document.getElementById('n5').value).toBe('5');
+  const saved = JSON.parse(localStorage.getItem('budgetInputs'));
+  expect(saved.n1).toBe('1');
+  expect(saved.n5).toBe('5');
+});
+
 test('saves inputs to localStorage on input', () => {
   setupDOM();
   require('../budget-ui.js');


### PR DESCRIPTION
## Summary
- Map legacy `esi1`–`esi5` keys to `n1`–`n5` when loading budget planner inputs
- Store normalized values back to localStorage
- Test fallback from `esi` keys to `n` keys

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c030fc7d14832081dc6e530f0e95ea