### PR TITLE
Preserve base rate fields for budget planner

### DIFF
--- a/budget-ui.js
+++ b/budget-ui.js
@@ -281,6 +281,12 @@ function loadInputs(){
       if (els[id] && saved[id] !== undefined) els[id].value = saved[id];
     });
 
+    if (localStorage.getItem('ratesFromZone') === '1') {
+      const notice = document.getElementById('zoneRatesNotice');
+      if (notice) notice.style.display = 'block';
+      localStorage.removeItem('ratesFromZone');
+    }
+
     localStorage.setItem(STORAGE_KEY, JSON.stringify(saved));
   }catch{}
 }

--- a/budget.html
+++ b/budget.html
@@ -35,6 +35,8 @@
       <button id="goBack" type="button">Grįžti</button>
     </div>
 
+    <p id="zoneRatesNotice" style="display:none;color:var(--accent-2);">Tarifai gauti iš zonos skaičiuoklės.</p>
+
     <div class="grid grid-2 budget-grid">
       <div class="card">
         <h2>Įvestis</h2>

--- a/src/ui.js
+++ b/src/ui.js
@@ -397,6 +397,7 @@ function goToBudgetPlanner(){
       n5: els.esi5?.value,
     };
     localStorage.setItem('budgetInputs', JSON.stringify(inputs));
+    localStorage.setItem('ratesFromZone', '1');
   } catch {
     alert('Nepavyko išsaugoti duomenų.');
   }

--- a/ui.js
+++ b/ui.js
@@ -424,6 +424,31 @@ function resetAll(){
   compute();
 }
 
+function goToBudgetPlanner(){
+  try {
+    const inputs = {
+      zoneCapacity: els.zoneCapacity?.value,
+      patientCount: els.patientCount?.value,
+      maxCoefficient: els.maxCoefficient?.value,
+      shiftHours: els.shiftHours?.value,
+      monthHours: els.monthHours?.value,
+      baseRateDoc: els.baseRateDoc?.value,
+      baseRateNurse: els.baseRateNurse?.value,
+      baseRateAssist: els.baseRateAssist?.value,
+      n1: els.esi1?.value,
+      n2: els.esi2?.value,
+      n3: els.esi3?.value,
+      n4: els.esi4?.value,
+      n5: els.esi5?.value,
+    };
+    localStorage.setItem('budgetInputs', JSON.stringify(inputs));
+    localStorage.setItem('ratesFromZone', '1');
+  } catch {
+    alert('Nepavyko išsaugoti duomenų.');
+  }
+  window.location.href = 'budget.html';
+}
+
 // Events
 ['input','change'].forEach(evt => {
   ['date','zone','zoneCapacity','patientCount','maxCoefficient','shiftHours','monthHours','baseRateDoc','baseRateNurse','baseRateAssist','linkPatientCount','esi1','esi2','esi3','esi4','esi5'].forEach(id => {
@@ -465,7 +490,7 @@ els.saveRateTemplate.addEventListener('click', (e)=>{ e.preventDefault(); saveRa
 els.loadRateTemplate.addEventListener('click', (e)=>{ e.preventDefault(); loadRateTemplate(); });
 
 if (els.budgetPlanner) {
-  els.budgetPlanner.addEventListener('click', (e)=>{ e.preventDefault(); window.location.href = 'budget.html'; });
+  els.budgetPlanner.addEventListener('click', (e)=>{ e.preventDefault(); goToBudgetPlanner(); });
 }
 
 // Step management


### PR DESCRIPTION
## Summary
- include base doctor, nurse, and assistant rates when navigating from zone calculator to budget planner
- show one-time notice on budget page when rates were imported from zone calculator

## Testing
- `npm test`
- `npm run lint` *(fails: Parsing error: 'import' and 'export' may appear only with 'sourceType: module')*

------
https://chatgpt.com/codex/tasks/task_e_68c03a158dfc8320822439a39e106fd6