### PR TITLE
Expose advanced options and adjust scroll behavior

### DIFF
--- a/budget.html
+++ b/budget.html
@@ -185,12 +185,12 @@
         </div>
 
         <div class="step" data-step="4">
-        <details id="advanced-section" class="section">
+        <details id="advanced-section" class="section" open>
           <summary>Išplėstinės parinktys</summary>
           <div class="row">
             <div>
               <label for="maxCoefficient">Maksimalus koeficientas</label>
-              <input id="maxCoefficient" type="number" min="0" step="0.01" value="1" />
+              <input id="maxCoefficient" type="number" min="0" step="0.01" value="1.30" />
             </div>
           </div>
           <div class="row-3">

--- a/index.html
+++ b/index.html
@@ -180,7 +180,7 @@
         </div>
 
         <div class="step" data-step="4">
-        <details id="advanced-section" class="section">
+        <details id="advanced-section" class="section" open>
           <summary>Išplėstinės parinktys</summary>
           <div class="row">
             <div>

--- a/styles.css
+++ b/styles.css
@@ -86,6 +86,8 @@
     @media (min-width: 960px) { .grid-2 { grid-template-columns: 1.2fr 0.8fr; } }
     /* Zoninio koeficiento skaičiuoklėje slankiojimo juosta tarp dalių */
     @media (min-width: 960px) { .calc-grid { grid-template-columns: 1.2fr 5px 0.8fr; } }
+    /* Abiejų Zoninio koeficiento skaičiuoklės kortelių atskiras slinkimas */
+    .calc-grid .card { overflow-y: auto; }
     /* Biudžeto planavimo skaičiuoklėje rezultatai turi būti platesni nei įvestis */
     @media (min-width: 960px) { .budget-grid { grid-template-columns: 0.6fr 5px 1.4fr; } }
     .card {


### PR DESCRIPTION
## Summary
- keep advanced sections expanded on both calculators
- default budget max coefficient to 1.3
- allow zone calculator cards to scroll independently

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68c03c034498832091eb241bbc3ee73c