### PR TITLE
feat: allow custom tariff roles

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Atlyginimo Skaičiuoklė
 
-Šis projektas – internetinis įrankis atlyginimo tarifams skaičiuoti skubios pagalbos skyriuje. Jis apskaičiuoja zonos koeficientą pagal pacientų skaičių ir triažo lygius, tuomet pritaiko jį baziniams gydytojų, slaugytojų ir padėjėjų valandiniams tarifams ir pateikia galutines sumas.
+Šis projektas – internetinis įrankis atlyginimo tarifams skaičiuoti skubios pagalbos skyriuje. Jis apskaičiuoja zonos koeficientą pagal pacientų skaičių ir triažo lygius, tuomet pritaiko jį baziniams gydytojų, slaugytojų, padėjėjų ir kitų pasirenkamų rolių valandiniams tarifams ir pateikia galutines sumas.
 
 Taip pat galite įvesti pamainos trukmę ir mėnesio valandų skaičių, kad pamatytumėte numatomą uždarbį už pamainą ar mėnesį.
 

--- a/index.html
+++ b/index.html
@@ -138,6 +138,9 @@
               <div class="help">Jei nėra triažo – palikite visur nulį.</div>
             </div>
           </div>
+          <div class="actions">
+            <button id="simulateEsi">Simuliuoti pamainą</button>
+          </div>
         </fieldset>
         <div class="step-nav actions">
           <button type="button" class="back-step">Atgal</button>
@@ -166,12 +169,14 @@
             <div>
               <label>&nbsp;</label>
               <div class="actions">
+                <button id="addRateRole" type="button">+ Pridėti rolę</button>
                 <button id="saveRateTemplate">Įsiminti tarifų šabloną</button>
                 <button id="loadRateTemplate">Užkrauti šabloną</button>
               </div>
               <div class="help">Tarifų šablonas saugomas vietoje (localStorage).</div>
             </div>
           </div>
+          <div id="extraRateList"></div>
         </fieldset>
         <div class="step-nav actions">
           <button type="button" class="back-step">Atgal</button>
@@ -218,7 +223,6 @@
         </div>
 
         <div class="actions">
-          <button id="simulateEsi">Simuliuoti pamainą</button>
           <button class="primary" id="reset">Išvalyti</button>
           <button id="copy">Kopijuoti rezultatą (JSON)</button>
           <button id="downloadCsv">Atsisiųsti CSV</button>
@@ -302,16 +306,16 @@
         </table>
 
         <h2 class="role-heading">Tarifai pagal rolę</h2>
-        <table class="table">
-          <thead>
-            <tr><th>Rolė</th><th>Bazė (€/val.)</th><th>Koef. K<sub>zona</sub></th><th>Galutinis (€/val.)</th><th>Pam. alga (€/pam.)</th><th>Mėn. alga (€/mėn.)</th><th>Improvement</th></tr>
-          </thead>
-          <tbody>
-            <tr><td>Gydytojas</td><td id="baseDocCell">€0,00</td><td id="kDocCell">1,00</td><td class="accent" id="finalDocCell">€0,00</td><td id="shiftDocCell">€0,00</td><td id="monthDocCell">€0,00</td><td id="deltaDocCell">€0,00 / €0,00</td></tr>
-            <tr><td>Slaugytojas</td><td id="baseNurseCell">€0,00</td><td id="kNurseCell">1,00</td><td class="accent" id="finalNurseCell">€0,00</td><td id="shiftNurseCell">€0,00</td><td id="monthNurseCell">€0,00</td><td id="deltaNurseCell">€0,00 / €0,00</td></tr>
-            <tr><td>Padėjėjas</td><td id="baseAssistCell">€0,00</td><td id="kAssistCell">1,00</td><td class="accent" id="finalAssistCell">€0,00</td><td id="shiftAssistCell">€0,00</td><td id="monthAssistCell">€0,00</td><td id="deltaAssistCell">€0,00 / €0,00</td></tr>
-          </tbody>
-        </table>
+          <table class="table">
+            <thead>
+              <tr><th>Rolė</th><th>Bazė (€/val.)</th><th>Koef. K<sub>zona</sub></th><th>Galutinis (€/val.)</th><th>Pam. alga (€/pam.)</th><th>Mėn. alga (€/mėn.)</th><th>Improvement</th></tr>
+            </thead>
+            <tbody id="rateTbody">
+              <tr><td>Gydytojas</td><td id="baseDocCell">€0,00</td><td id="kDocCell">1,00</td><td class="accent" id="finalDocCell">€0,00</td><td id="shiftDocCell">€0,00</td><td id="monthDocCell">€0,00</td><td id="deltaDocCell">€0,00 / €0,00</td></tr>
+              <tr><td>Slaugytojas</td><td id="baseNurseCell">€0,00</td><td id="kNurseCell">1,00</td><td class="accent" id="finalNurseCell">€0,00</td><td id="shiftNurseCell">€0,00</td><td id="monthNurseCell">€0,00</td><td id="deltaNurseCell">€0,00 / €0,00</td></tr>
+              <tr><td>Padėjėjas</td><td id="baseAssistCell">€0,00</td><td id="kAssistCell">1,00</td><td class="accent" id="finalAssistCell">€0,00</td><td id="shiftAssistCell">€0,00</td><td id="monthAssistCell">€0,00</td><td id="deltaAssistCell">€0,00 / €0,00</td></tr>
+            </tbody>
+          </table>
         <div class="footer">
           Patarimas: jei dažnai pasiekiate lubas, padidinkite zonos talpą arba sumažinkite priedų laiptelius.
         </div>

--- a/src/ui.js
+++ b/src/ui.js
@@ -170,6 +170,34 @@ function toNum(v) { const n = Number(v); return Number.isFinite(n) ? n : 0; }
 function fmt(n, d=2) { return (Number.isFinite(n) ? n : 0).toFixed(d); }
 function money(n) { try { return new Intl.NumberFormat('lt-LT',{style:'currency',currency:'EUR'}).format(n||0); } catch { return `€${fmt(n)}`; } }
 
+function getExtraRates(){
+  const rates = {};
+  if (!els.extraRateList) return rates;
+  els.extraRateList.querySelectorAll('.extra-rate-row').forEach(row => {
+    const name = row.querySelector('.role-name')?.value.trim();
+    const rate = toNum(row.querySelector('.role-rate')?.value);
+    if (name) rates[name] = Math.max(0, rate);
+  });
+  return rates;
+}
+
+function addRateRole(name = '', rate = 0){
+  if (!els.extraRateList) return;
+  const row = document.createElement('div');
+  row.className = 'row extra-rate-row';
+  row.innerHTML = `
+    <div>
+      <input type="text" class="role-name" placeholder="Rolės pavadinimas" value="${name}" />
+    </div>
+    <div>
+      <input type="number" min="0" step="0.01" class="role-rate" value="${rate}" />
+      <button type="button" class="remove-rate-role">Šalinti</button>
+    </div>`;
+  els.extraRateList.appendChild(row);
+  row.querySelectorAll('input').forEach(inp => inp.addEventListener('input', compute));
+  row.querySelector('.remove-rate-role').addEventListener('click', () => { row.remove(); compute(); });
+}
+
 function validateInputs(){
   ['zoneCapacity','patientCount','maxCoefficient','shiftHours','monthHours','baseRateDoc','baseRateNurse','baseRateAssist','esi1','esi2','esi3','esi4','esi5'].forEach(id => {
     const el = els[id];
@@ -208,12 +236,14 @@ function compute(){
   let patientCount = Math.max(0, toNum(els.patientCount.value));
   if (els.linkPatientCount.checked){ patientCount = n1 + n2 + n3 + n4 + n5; els.patientCount.value = patientCount; els.patientCount.disabled = true; } else els.patientCount.disabled = false;
 
+  const extraRates = getExtraRates();
   const data = coreCompute({
     zoneCapacity,
     maxCoefficient,
     baseDoc,
     baseNurse,
     baseAssist,
+    extraRates,
     shiftH,
     monthH,
     n1,
@@ -279,6 +309,17 @@ function compute(){
   els.monthAssistCell.textContent = money(data.month_salary.assistant);
   els.deltaAssistCell.textContent = `${money(data.shift_salary.assistant - data.baseline_shift_salary.assistant)} / ${money(data.month_salary.assistant - data.baseline_month_salary.assistant)}`;
 
+  if (els.rateTbody) {
+    Array.from(els.rateTbody.querySelectorAll('.extra-rate-result')).forEach(r => r.remove());
+    for (const role of Object.keys(data.base_rates)) {
+      if (['doctor','nurse','assistant'].includes(role)) continue;
+      const tr = document.createElement('tr');
+      tr.className = 'extra-rate-result';
+      tr.innerHTML = `<td>${role}</td><td>${money(data.base_rates[role])}</td><td>${data.K_zona.toFixed(2)}</td><td class="accent">${money(data.final_rates[role])}</td><td>${money(data.shift_salary[role])}</td><td>${money(data.month_salary[role])}</td><td>${money(data.shift_salary[role]-data.baseline_shift_salary[role])} / ${money(data.month_salary[role]-data.baseline_month_salary[role])}</td>`;
+      els.rateTbody.appendChild(tr);
+    }
+  }
+
   return {
     date: els.date.value || null,
     shift: els.shift.value,
@@ -330,7 +371,8 @@ function onSaveRateTemplate(){
   const payload = {
     doc: toNum(els.baseRateDoc.value),
     nurse: toNum(els.baseRateNurse.value),
-    assist: toNum(els.baseRateAssist.value)
+    assist: toNum(els.baseRateAssist.value),
+    extra: getExtraRates()
   };
   if (saveRateTemplate(payload)) {
     alert('Tarifų šablonas įsimintas.');
@@ -343,6 +385,10 @@ function onLoadRateTemplate(){
     els.baseRateDoc.value = t.doc ?? 0;
     els.baseRateNurse.value = t.nurse ?? 0;
     els.baseRateAssist.value = t.assist ?? 0;
+    if (els.extraRateList) els.extraRateList.innerHTML = '';
+    if (t.extra) {
+      Object.entries(t.extra).forEach(([name, rate]) => addRateRole(name, rate));
+    }
     compute();
   } else {
     alert('Nerasta išsaugoto šablono.');
@@ -355,11 +401,15 @@ function resetAll(){
   els.patientCount.value = 0; els.maxCoefficient.value = 1.30; els.linkPatientCount.checked = true;
   els.shiftHours.value = 12; els.monthHours.value = 0;
   els.esi1.value = 0; els.esi2.value = 0; els.esi3.value = 0; els.esi4.value = 0; els.esi5.value = 0;
+  if (els.extraRateList) els.extraRateList.innerHTML = '';
   const t = loadRateTemplate();
   if (t) {
     els.baseRateDoc.value = t.doc ?? 0;
     els.baseRateNurse.value = t.nurse ?? 0;
     els.baseRateAssist.value = t.assist ?? 0;
+    if (t.extra) {
+      Object.entries(t.extra).forEach(([name, rate]) => addRateRole(name, rate));
+    }
   } else {
     els.baseRateDoc.value = 0; els.baseRateNurse.value = 0; els.baseRateAssist.value = 0;
   }
@@ -379,7 +429,7 @@ function copyResults(){
 
 function onDownloadCsv(){ downloadCsv(compute()); }
 function onDownloadPdf(){ downloadPdf(compute()); }
-function goToBudgetPlanner(){
+  function goToBudgetPlanner(){
   try {
     const inputs = {
       zoneCapacity: els.zoneCapacity?.value,
@@ -390,6 +440,7 @@ function goToBudgetPlanner(){
       baseRateDoc: els.baseRateDoc?.value,
       baseRateNurse: els.baseRateNurse?.value,
       baseRateAssist: els.baseRateAssist?.value,
+      extraRates: getExtraRates(),
       n1: els.esi1?.value,
       n2: els.esi2?.value,
       n3: els.esi3?.value,
@@ -420,10 +471,11 @@ bindEvents(els, {
   saveZonesAndClose,
   resetToDefaults,
   closeZoneModal,
-  saveRateTemplate: onSaveRateTemplate,
-  loadRateTemplate: onLoadRateTemplate,
-  goToBudgetPlanner,
-});
+    saveRateTemplate: onSaveRateTemplate,
+    loadRateTemplate: onLoadRateTemplate,
+    goToBudgetPlanner,
+    addRateRole,
+  });
 
 renderZoneSelect(false);
 resetAll();

--- a/src/ui/dom.js
+++ b/src/ui/dom.js
@@ -43,6 +43,9 @@ export function getElements() {
     shiftAssistCell: document.getElementById('shiftAssistCell'),
     monthAssistCell: document.getElementById('monthAssistCell'),
     deltaAssistCell: document.getElementById('deltaAssistCell'),
+    rateTbody: document.getElementById('rateTbody'),
+    extraRateList: document.getElementById('extraRateList'),
+    addRateRole: document.getElementById('addRateRole'),
     simulateEsi: document.getElementById('simulateEsi'),
     days: document.getElementById('days'),
     simulatePeriod: document.getElementById('simulatePeriod'),
@@ -96,6 +99,7 @@ export function bindEvents(els, handlers) {
     saveRateTemplate,
     loadRateTemplate,
     goToBudgetPlanner,
+    addRateRole,
   } = handlers;
 
   ['input','change'].forEach(evt => {
@@ -128,6 +132,9 @@ export function bindEvents(els, handlers) {
 
   els.saveRateTemplate.addEventListener('click', e => { e.preventDefault(); saveRateTemplate(); });
   els.loadRateTemplate.addEventListener('click', e => { e.preventDefault(); loadRateTemplate(); });
+  if (els.addRateRole) {
+    els.addRateRole.addEventListener('click', e => { e.preventDefault(); addRateRole(); });
+  }
 
   if (els.budgetPlanner) {
     els.budgetPlanner.addEventListener('click', e => { e.preventDefault(); goToBudgetPlanner(); });

--- a/tests/compute.test.js
+++ b/tests/compute.test.js
@@ -172,4 +172,25 @@ describe('compute core logic', () => {
     expect(result.shift_salary.doctor).toBe(0);
     expect(result.month_salary.doctor).toBe(0);
   });
+
+  test('handles extra rate roles', () => {
+    const result = compute({
+      zoneCapacity: 10,
+      patientCount: 10,
+      maxCoefficient: 2,
+      baseDoc: 0,
+      baseNurse: 0,
+      baseAssist: 0,
+      extraRates: { tech: 5 },
+      shiftH: 1,
+      monthH: 10,
+      n1: 0,
+      n2: 0,
+      n3: 0,
+      n4: 0,
+      n5: 0,
+    });
+    expect(result.final_rates.tech).toBeCloseTo(5 * result.K_zona);
+    expect(result.shift_salary.tech).toBeCloseTo(result.final_rates.tech * 1);
+  });
 });

--- a/tests/goToBudgetPlanner.test.js
+++ b/tests/goToBudgetPlanner.test.js
@@ -152,6 +152,7 @@ test('stores inputs to localStorage', () => {
     baseRateDoc: '20',
     baseRateNurse: '15',
     baseRateAssist: '10',
+    extraRates: {},
     n1: '1',
     n2: '2',
     n3: '3',


### PR DESCRIPTION
## Summary
- move shift simulation button into patient distribution step
- support adding and saving custom tariff roles with dynamic result rows
- document optional roles in README

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68c0401f22ac8320b057948c29d9fbeb