### PR TITLE
Show role names in tariff chart legend

### DIFF
--- a/chart-utils.js
+++ b/chart-utils.js
@@ -29,7 +29,28 @@ export function createBudgetChart(canvas, type = 'bar') {
       ]
     },
     options: {
-      plugins: { legend: { display: true } },
+      plugins: {
+        legend: {
+          display: true,
+          // Doughnut charts with multiple datasets show only dataset labels by default.
+          // Generate legend items from role labels so each color is mapped to a role.
+          labels: type === 'doughnut' ? {
+            generateLabels(chart) {
+              const { labels = [], datasets = [] } = chart.data || {};
+              const base = datasets[0] || {};
+              const bg = Array.isArray(base.backgroundColor) ? base.backgroundColor : [];
+              const bd = Array.isArray(base.borderColor) ? base.borderColor : bg;
+              return labels.map((text, i) => ({
+                text,
+                fillStyle: bg[i],
+                strokeStyle: bd[i],
+                hidden: false,
+                index: i,
+              }));
+            }
+          } : {},
+        },
+      },
       scales: type === 'bar' ? { x: { stacked: true }, y: { stacked: true, beginAtZero: true } } : {},
       maintainAspectRatio: false,
       responsive: true,

--- a/src/chart/index.js
+++ b/src/chart/index.js
@@ -29,7 +29,27 @@ export function createBudgetChart(canvas, type = 'bar') {
       ],
     },
     options: {
-      plugins: { legend: { display: true } },
+      plugins: {
+        legend: {
+          display: true,
+          // For doughnut charts ensure legend items show role names instead of dataset names.
+          labels: type === 'doughnut' ? {
+            generateLabels(chart) {
+              const { labels = [], datasets = [] } = chart.data || {};
+              const base = datasets[0] || {};
+              const bg = Array.isArray(base.backgroundColor) ? base.backgroundColor : [];
+              const bd = Array.isArray(base.borderColor) ? base.borderColor : bg;
+              return labels.map((text, i) => ({
+                text,
+                fillStyle: bg[i],
+                strokeStyle: bd[i],
+                hidden: false,
+                index: i,
+              }));
+            }
+          } : {},
+        },
+      },
       scales: type === 'bar' ? { x: { stacked: true }, y: { stacked: true, beginAtZero: true } } : {},
       maintainAspectRatio: false,
       responsive: true,

--- a/tests/chart-utils.test.js
+++ b/tests/chart-utils.test.js
@@ -46,6 +46,21 @@ describe('createBudgetChart', () => {
     expect(chart).toBeTruthy();
     delete global.Chart;
   });
+
+  test('doughnut chart uses role names in legend', () => {
+    const ctx = {};
+    const canvas = { getContext: jest.fn(() => ctx) };
+    let passedConfig;
+    global.Chart = jest.fn((c, cfg) => {
+      passedConfig = cfg;
+      return { data: cfg.data, options: cfg.options, update: jest.fn() };
+    });
+    createBudgetChart(canvas, 'doughnut');
+    const gen = passedConfig.options.plugins.legend.labels.generateLabels;
+    const items = gen({ data: { labels: ['A','B'], datasets: [{ backgroundColor:['#000','#111'], borderColor:['#000','#111'] }] } });
+    expect(items.map(i => i.text)).toEqual(['A','B']);
+    delete global.Chart;
+  });
 });
 
 describe('updateBudgetChart', () => {


### PR DESCRIPTION
## Summary
- generate legend items from role labels so tariff chart shows doctor/nurse/assistant names
- keep source chart module in sync
- test doughnut chart legend generation

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68c05b2a50c08320a194dcd51921c1de