### PR TITLE
feat: switchable computation variants

### DIFF
--- a/index.html
+++ b/index.html
@@ -87,6 +87,15 @@
               <input id="monthHours" type="number" min="0" step="0.5" value="0" />
             </div>
           </div>
+          <div class="row">
+            <div>
+              <label for="calcVariant">Skaičiavimas</label>
+              <select id="calcVariant">
+                <option value="legacy">Senasis</option>
+                <option value="ladder">Ladder</option>
+              </select>
+            </div>
+          </div>
         </fieldset>
         <div class="step-nav actions">
           <button type="button" class="next-step">Toliau</button>

--- a/src/ui/dom.js
+++ b/src/ui/dom.js
@@ -12,6 +12,7 @@ export function getElements() {
     baseRateNurse: document.getElementById('baseRateNurse'),
     baseRateAssist: document.getElementById('baseRateAssist'),
     linkPatientCount: document.getElementById('linkPatientCount') || document.getElementById('linkN'),
+    calcVariant: document.getElementById('calcVariant'),
     esi1: document.getElementById('esi1'),
     esi2: document.getElementById('esi2'),
     esi3: document.getElementById('esi3'),

--- a/tests/calc-variant-ui.test.js
+++ b/tests/calc-variant-ui.test.js
@@ -1,0 +1,122 @@
+jest.mock('../theme.js', () => ({ initThemeToggle: jest.fn() }));
+
+const mockZoneApi = {
+  renderZoneSelect: jest.fn(),
+  setDefaultCapacity: jest.fn(),
+  openZoneModal: jest.fn(),
+  closeZoneModal: jest.fn(),
+  addZone: jest.fn(),
+  saveZonesAndClose: jest.fn(),
+  resetToDefaults: jest.fn(),
+  getZones: jest.fn(() => []),
+};
+
+jest.mock('../zones.js', () => ({ initZones: jest.fn(() => mockZoneApi) }));
+jest.mock('../downloads.js', () => ({ downloadCsv: jest.fn(), downloadPdf: jest.fn() }));
+jest.mock('../src/chart/index.js', () => ({ updateChart: jest.fn() }));
+jest.mock('../src/chart/utils.js', () => ({ safeCreateChart: jest.fn() }));
+jest.mock('../simulation.js', () => ({ simulateEsiCounts: jest.fn(() => ({ total: 0, counts: [0,0,0,0,0] })) }));
+jest.mock('../src/storage.js', () => ({ saveRateTemplate: jest.fn(), loadRateTemplate: jest.fn(() => null) }));
+
+let mockEls;
+
+jest.mock('../src/ui/dom.js', () => ({
+  getElements: jest.fn(() => mockEls),
+  bindEvents: jest.fn(),
+}));
+
+beforeEach(() => {
+  jest.resetModules();
+  localStorage.clear();
+  const makeInput = (val='') => ({ value: val, classList: { add: jest.fn(), remove: jest.fn() }, disabled: false, removeAttribute: jest.fn() });
+  mockEls = {
+    zoneCapacity: makeInput(),
+    patientCount: makeInput(),
+    maxCoefficient: makeInput(),
+    shiftHours: makeInput(),
+    monthHours: makeInput(),
+    baseRateDoc: makeInput(),
+    baseRateNurse: makeInput(),
+    baseRateAssist: makeInput(),
+    esi1: makeInput(),
+    esi2: makeInput(),
+    esi3: makeInput(),
+    esi4: makeInput(),
+    esi5: makeInput(),
+    linkPatientCount: { checked: false },
+    ratio: { textContent: '' },
+    sShare: { textContent: '' },
+    vBonus: { textContent: '' },
+    aBonus: { textContent: '' },
+    maxCoefficientCell: { textContent: '' },
+    kZona: { textContent: '' },
+    baseDocCell: { textContent: '' },
+    kDocCell: { textContent: '' },
+    finalDocCell: { textContent: '' },
+    shiftDocCell: { textContent: '' },
+    monthDocCell: { textContent: '' },
+    deltaDocCell: { textContent: '' },
+    baseNurseCell: { textContent: '' },
+    kNurseCell: { textContent: '' },
+    finalNurseCell: { textContent: '' },
+    shiftNurseCell: { textContent: '' },
+    monthNurseCell: { textContent: '' },
+    deltaNurseCell: { textContent: '' },
+    baseAssistCell: { textContent: '' },
+    kAssistCell: { textContent: '' },
+    finalAssistCell: { textContent: '' },
+    shiftAssistCell: { textContent: '' },
+    monthAssistCell: { textContent: '' },
+    deltaAssistCell: { textContent: '' },
+    ratioCanvas: null,
+    sCanvas: null,
+    payCanvas: null,
+    simulateEsi: { addEventListener: jest.fn() },
+    reset: { addEventListener: jest.fn() },
+    copy: { addEventListener: jest.fn() },
+    downloadCsv: { addEventListener: jest.fn() },
+    downloadPdf: { addEventListener: jest.fn() },
+    manageZones: { addEventListener: jest.fn() },
+    zoneModal: {},
+    zoneTbody: {},
+    addZone: { addEventListener: jest.fn() },
+    saveZonesBtn: { addEventListener: jest.fn() },
+    defaultsZones: { addEventListener: jest.fn() },
+    closeZoneModal: { addEventListener: jest.fn() },
+    saveRateTemplate: { addEventListener: jest.fn() },
+    loadRateTemplate: { addEventListener: jest.fn() },
+    budgetPlanner: { addEventListener: jest.fn() },
+    zone: { value: 'RED', addEventListener: jest.fn(), innerHTML: '', appendChild: jest.fn() },
+    shift: { value: 'D', addEventListener: jest.fn() },
+    date: { value: '' },
+    calcVariant: { value: 'legacy', addEventListener: jest.fn() },
+  };
+});
+
+test('calcVariant switch recalculates coefficient', () => {
+  const { compute } = require('../src/ui.js');
+  mockEls.zoneCapacity.value = '100';
+  mockEls.patientCount.value = '50';
+  mockEls.maxCoefficient.value = '2';
+  mockEls.shiftHours.value = '12';
+  mockEls.monthHours.value = '0';
+  mockEls.baseRateDoc.value = '10';
+  mockEls.baseRateNurse.value = '10';
+  mockEls.baseRateAssist.value = '10';
+  mockEls.esi1.value = '10';
+  mockEls.esi2.value = '5';
+  mockEls.esi3.value = '35';
+  mockEls.esi4.value = '0';
+  mockEls.esi5.value = '0';
+
+  compute();
+  const legacy = parseFloat(mockEls.kZona.textContent);
+
+  mockEls.calcVariant.value = 'ladder';
+  const handler = mockEls.calcVariant.addEventListener.mock.calls[0][1];
+  handler();
+  const ladder = parseFloat(mockEls.kZona.textContent);
+
+  expect(legacy).toBeCloseTo(1.10);
+  expect(ladder).toBeCloseTo(1.15);
+});

--- a/ui.js
+++ b/ui.js
@@ -1,11 +1,12 @@
 import { initThemeToggle } from './theme.js';
 import { initZones } from './zones.js';
 import { downloadCsv, downloadPdf } from './downloads.js';
-import { compute as coreCompute } from './compute.js';
+import { computeVariant, DEFAULT_KZ_CONFIG } from './kz-variant.js';
 import { updateChart } from './chart-utils.js';
 import { simulateEsiCounts } from './simulation.js';
 
 const LS_RATE_KEY = 'ED_RATE_TEMPLATE_V2';
+const LS_VARIANT_KEY = 'CALC_VARIANT';
 
 const els = {
   date: document.getElementById('date'),
@@ -20,6 +21,7 @@ const els = {
   baseRateNurse: document.getElementById('baseRateNurse'),
   baseRateAssist: document.getElementById('baseRateAssist'),
   linkPatientCount: document.getElementById('linkPatientCount') || document.getElementById('linkN'),
+  calcVariant: document.getElementById('calcVariant'),
   esi1: document.getElementById('esi1'),
   esi2: document.getElementById('esi2'),
   esi3: document.getElementById('esi3'),
@@ -78,6 +80,11 @@ els.N = els.patientCount;
 els.kmax = els.maxCoefficient;
 els.linkN = els.linkPatientCount;
 els.kMaxCell = els.maxCoefficientCell;
+
+const savedVariant = localStorage.getItem(LS_VARIANT_KEY);
+if (els.calcVariant && savedVariant) {
+  els.calcVariant.value = savedVariant;
+}
 
 initThemeToggle();
 
@@ -278,6 +285,7 @@ function validateInputs(){
 
 function compute(){
   validateInputs();
+  const variant = els.calcVariant ? els.calcVariant.value : 'legacy';
   const zoneCapacity = Math.max(0, toNum(els.zoneCapacity.value));
   const maxCoefficient = Math.min(2, Math.max(1, toNum(els.maxCoefficient.value)));
   const baseDoc = Math.max(0, toNum(els.baseRateDoc.value));
@@ -295,22 +303,84 @@ function compute(){
   if (els.linkPatientCount.checked){ patientCount = n1 + n2 + n3 + n4 + n5; els.patientCount.value = patientCount; els.patientCount.disabled = true; } else els.patientCount.disabled = false;
 
   const extraRates = getExtraRates();
-  const data = coreCompute({
-    zoneCapacity,
-    maxCoefficient,
-    baseDoc,
-    baseNurse,
-    baseAssist,
-    extraRates,
-    shiftH,
-    monthH,
-    n1,
-    n2,
-    n3,
-    n4,
-    n5,
-    patientCount,
-  });
+  let data;
+  if (variant === 'ladder') {
+    const cfg = DEFAULT_KZ_CONFIG;
+    const ratio = zoneCapacity > 0 ? patientCount / zoneCapacity : 0;
+    const S = patientCount > 0 ? (n1 + n2) / patientCount : 0;
+    let V = 0;
+    for (const step of cfg.volume_ladder) {
+      if (ratio <= step.r_max) { V = step.bonus; break; }
+    }
+    if (S < cfg.low_S_threshold) {
+      V = Math.min(V, cfg.volume_cap_if_low_S);
+    }
+    let A = 0;
+    for (const step of cfg.triage_ladder) {
+      if (S <= step.s_max) { A = step.bonus; break; }
+    }
+    const cfgCap = { ...(cfg.capacity_defaults[els.zone.value] || {}) };
+    cfgCap[els.shift.value] = zoneCapacity;
+    const cfg2 = { ...cfg, k_max: maxCoefficient, capacity_defaults: { ...cfg.capacity_defaults, [els.zone.value]: cfgCap } };
+    const kz = computeVariant('ladder', {
+      esi: [n1, n2, n3, n4, n5],
+      zone: els.zone.value,
+      shift: els.shift.value,
+      base_rate_eur_h: 1,
+      shift_hours: 1,
+      cfg: cfg2,
+    }).K_zona;
+    const K = kz;
+    const roles = { doctor: baseDoc, nurse: baseNurse, assistant: baseAssist, ...extraRates };
+    const base_rates = { ...roles };
+    const baseline_shift_salary = {};
+    const baseline_month_salary = {};
+    const final_rates = {};
+    const shift_salary = {};
+    const month_salary = {};
+    for (const [role, base] of Object.entries(roles)) {
+      const clean = Math.max(0, base);
+      final_rates[role] = clean * K;
+      shift_salary[role] = final_rates[role] * shiftH;
+      month_salary[role] = final_rates[role] * monthH;
+      baseline_shift_salary[role] = clean * shiftH;
+      baseline_month_salary[role] = clean * monthH;
+    }
+    data = {
+      patientCount,
+      ratio,
+      S,
+      V_bonus: V,
+      A_bonus: A,
+      maxCoefficient,
+      K_zona: K,
+      shift_hours: shiftH,
+      month_hours: monthH,
+      base_rates,
+      baseline_shift_salary,
+      baseline_month_salary,
+      final_rates,
+      shift_salary,
+      month_salary,
+    };
+  } else {
+    data = computeVariant('legacy', {
+      zoneCapacity,
+      maxCoefficient,
+      baseDoc,
+      baseNurse,
+      baseAssist,
+      extraRates,
+      shiftH,
+      monthH,
+      n1,
+      n2,
+      n3,
+      n4,
+      n5,
+      patientCount,
+    });
+  }
 
   els.ratio.textContent = fmt(data.ratio);
   els.sShare.textContent = fmt(data.S);
@@ -439,6 +509,10 @@ function handleShiftChange(){
   
   function resetAll(){
   els.date.value = ''; els.shift.value = 'D';
+  if (els.calcVariant) {
+    const sv = localStorage.getItem(LS_VARIANT_KEY);
+    els.calcVariant.value = sv || 'legacy';
+  }
   renderZoneSelect(false);
   els.patientCount.value = 0; els.maxCoefficient.value = 1.30; els.linkPatientCount.checked = true;
   els.shiftHours.value = 12; els.monthHours.value = 0;
@@ -496,6 +570,12 @@ function handleShiftChange(){
     if (el) el.addEventListener(evt, compute);
   });
 });
+if (els.calcVariant) {
+  els.calcVariant.addEventListener('change', () => {
+    try { localStorage.setItem(LS_VARIANT_KEY, els.calcVariant.value); } catch {}
+    compute();
+  });
+}
 els.shift.addEventListener('change', handleShiftChange);
 els.zone.addEventListener('change', setDefaultCapacity);
 els.simulateEsi.addEventListener('click', (e)=>{ e.preventDefault(); simulateEsi(); });


### PR DESCRIPTION
## Summary
- add variant selector to shift parameters and persist choice
- compute zone coefficient using legacy or ladder algorithm via `computeVariant`
- recalc on variant change and cover with tests

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68c29d2070a08320a795b995b3f11e1e