### PR TITLE
Add formula switch for salary calculations

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,8 @@
 
 Taip pat galite įvesti pamainos trukmę ir mėnesio valandų skaičių, kad pamatytumėte numatomą uždarbį už pamainą ar mėnesį.
 
+Skaičiuoklėje galima perjungti formulę tarp „Triažas + apkrova“ ir „Laiptelinės“ versijų.
+
 Biudžeto planavimo įrankyje galima nurodyti minimalų gydytojų, slaugytojų ir padėjėjų skaičių. Šios reikšmės (`minDoctor`, `minNurse`, `minAssistant`) naudojamos optimizacijos metu, kad siūlomas personalo skaičius niekada nenukristų žemiau nustatytų ribų.
 
 ## Vykdymas vietoje

--- a/index.html
+++ b/index.html
@@ -201,6 +201,13 @@
           <summary>Išplėstinės parinktys</summary>
           <div class="row">
             <div>
+              <label for="formula">Skaičiavimo formulė</label>
+              <select id="formula">
+                <option value="legacy">Triažas + apkrova</option>
+                <option value="ladder">Laiptelinė</option>
+              </select>
+            </div>
+            <div>
               <label for="maxCoefficient">Maksimalus koeficientas</label>
               <input id="maxCoefficient" type="number" min="1" max="2" step="0.01" value="1.30" />
               <!-- formerly id="kmax" -->

--- a/kz-config.js
+++ b/kz-config.js
@@ -1,0 +1,27 @@
+export const DEFAULT_KZ_CONFIG = {
+  k_max: 1.30,
+  volume_ladder: [
+    { r_max: 1.00, bonus: 0.05 },
+    { r_max: 1.25, bonus: 0.10 },
+    { r_max: 1.60, bonus: 0.20 },
+    { r_max: 9.99, bonus: 0.30 }, // tik jei S ≥ 10%
+  ],
+  triage_ladder: [
+    { s_max: 0.10, bonus: 0.00 },
+    { s_max: 0.20, bonus: 0.05 },
+    { s_max: 0.30, bonus: 0.10 },
+    { s_max: 1.00, bonus: 0.15 },
+  ],
+  low_S_threshold: 0.10,
+  volume_cap_if_low_S: 0.20,
+  capacity_defaults: {
+    RED: { D: 16, N: 12 },
+    YEL: { D: 22, N: 15 },
+    GRN: { D: 28, N: 20 },
+    TRIAGE: { D: 35, N: 24 },
+    OBS: { D: 14, N: 10 },
+    PROCS: { D: 12, N: 10 },
+    PED: { D: 20, N: 14 },
+    OTHER: { D: 20, N: 16 },
+  },
+};

--- a/kz-variant.js
+++ b/kz-variant.js
@@ -1,35 +1,9 @@
 
 import { compute } from "./compute";
+import { DEFAULT_KZ_CONFIG } from "./kz-config.js";
 
-// Configuration and calculation variants for zone coefficient
-
-export const DEFAULT_KZ_CONFIG = {
-  k_max: 1.30,
-  volume_ladder: [
-    { r_max: 1.00, bonus: 0.05 },
-    { r_max: 1.25, bonus: 0.10 },
-    { r_max: 1.60, bonus: 0.20 },
-    { r_max: 9.99, bonus: 0.30 }, // tik jei S ≥ 10%
-  ],
-  triage_ladder: [
-    { s_max: 0.10, bonus: 0.00 },
-    { s_max: 0.20, bonus: 0.05 },
-    { s_max: 0.30, bonus: 0.10 },
-    { s_max: 1.00, bonus: 0.15 },
-  ],
-  low_S_threshold: 0.10,
-  volume_cap_if_low_S: 0.20,
-  capacity_defaults: {
-    RED: { D: 16, N: 12 },
-    YEL: { D: 22, N: 15 },
-    GRN: { D: 28, N: 20 },
-    TRIAGE: { D: 35, N: 24 },
-    OBS: { D: 14, N: 10 },
-    PROCS: { D: 12, N: 10 },
-    PED: { D: 20, N: 14 },
-    OTHER: { D: 20, N: 16 },
-  },
-};
+// Re-export so tests can import from this module
+export { DEFAULT_KZ_CONFIG };
 
 function round2(x) {
   return Math.round(x * 100) / 100;

--- a/tests/compute-formula.test.js
+++ b/tests/compute-formula.test.js
@@ -1,0 +1,43 @@
+import { compute } from '../compute';
+
+describe('compute formula switching', () => {
+  test('ladder variant caps volume when S is low', () => {
+    const params = {
+      zoneCapacity: 28,
+      patientCount: 0,
+      maxCoefficient: 1.3,
+      baseDoc: 10,
+      baseNurse: 10,
+      baseAssist: 10,
+      shiftH: 0,
+      monthH: 0,
+      n1: 0,
+      n2: 0,
+      n3: 30,
+      n4: 20,
+      n5: 10,
+    };
+    const out = compute(params, undefined, { formula: 'ladder' });
+    expect(out.K_zona).toBeCloseTo(1.20);
+  });
+
+  test('legacy formula remains default', () => {
+    const params = {
+      zoneCapacity: 28,
+      patientCount: 0,
+      maxCoefficient: 1.3,
+      baseDoc: 10,
+      baseNurse: 10,
+      baseAssist: 10,
+      shiftH: 0,
+      monthH: 0,
+      n1: 0,
+      n2: 0,
+      n3: 30,
+      n4: 20,
+      n5: 10,
+    };
+    const out = compute(params);
+    expect(out.K_zona).toBeCloseTo(1.15);
+  });
+});

--- a/ui.js
+++ b/ui.js
@@ -13,6 +13,7 @@ const els = {
   zone: document.getElementById('zone'),
   zoneCapacity: document.getElementById('zoneCapacity') || document.getElementById('capacity'),
   patientCount: document.getElementById('patientCount') || document.getElementById('N'),
+  formula: document.getElementById('formula'),
   maxCoefficient: document.getElementById('maxCoefficient') || document.getElementById('kmax'),
   shiftHours: document.getElementById('shiftHours'),
   monthHours: document.getElementById('monthHours'),
@@ -294,6 +295,7 @@ function compute(){
   let patientCount = Math.max(0, toNum(els.patientCount.value));
   if (els.linkPatientCount.checked){ patientCount = n1 + n2 + n3 + n4 + n5; els.patientCount.value = patientCount; els.patientCount.disabled = true; } else els.patientCount.disabled = false;
 
+  const formula = els.formula ? els.formula.value : 'legacy';
   const extraRates = getExtraRates();
   const data = coreCompute({
     zoneCapacity,
@@ -310,7 +312,7 @@ function compute(){
     n4,
     n5,
     patientCount,
-  });
+  }, undefined, { formula });
 
   els.ratio.textContent = fmt(data.ratio);
   els.sShare.textContent = fmt(data.S);
@@ -377,6 +379,7 @@ function compute(){
     shift: els.shift.value,
     zone: els.zone.value,
     zone_label: (getZones().find(z=>z.id===els.zone.value)?.name) || els.zone.value,
+    formula,
     zoneCapacity,
     ...data,
   };
@@ -441,6 +444,7 @@ function handleShiftChange(){
   els.date.value = ''; els.shift.value = 'D';
   renderZoneSelect(false);
   els.patientCount.value = 0; els.maxCoefficient.value = 1.30; els.linkPatientCount.checked = true;
+  if (els.formula) els.formula.value = 'legacy';
   els.shiftHours.value = 12; els.monthHours.value = 0;
   els.esi1.value = 0; els.esi2.value = 0; els.esi3.value = 0; els.esi4.value = 0; els.esi5.value = 0;
   if (els.extraRoles) els.extraRoles.innerHTML = '';
@@ -491,7 +495,7 @@ function handleShiftChange(){
 
 // Events
 ['input','change'].forEach(evt => {
-  ['date','zone','zoneCapacity','patientCount','maxCoefficient','shiftHours','monthHours','baseRateDoc','baseRateNurse','baseRateAssist','linkPatientCount','esi1','esi2','esi3','esi4','esi5'].forEach(id => {
+  ['date','zone','zoneCapacity','patientCount','formula','maxCoefficient','shiftHours','monthHours','baseRateDoc','baseRateNurse','baseRateAssist','linkPatientCount','esi1','esi2','esi3','esi4','esi5'].forEach(id => {
     const el = els[id];
     if (el) el.addEventListener(evt, compute);
   });


### PR DESCRIPTION
## Summary
- allow choosing between legacy and ladder salary formulas
- expose formula selector in UI and compute logic
- cover formula switching with tests

## Testing
- `npm test`
- `npm run lint` *(fails: Parsing error: 'import' and 'export' may appear only with 'sourceType: module')*

------
https://chatgpt.com/codex/tasks/task_e_68c2be6b07ac8320a6b864b2227c529b