### PR TITLE
feat: show formula details for formula modes

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,9 @@ Taip pat galite įvesti pamainos trukmę ir mėnesio valandų skaičių, kad pam
 
 Skaičiuoklėje galima perjungti formulę tarp „Triažas + apkrova“ ir „Laiptelinės“ versijų.
 
+* **Triažas + apkrova (legacy)** – du priedai apskaičiuojami pagal fiksuotas apkrovos ir triažo ribas.
+* **Laiptelinė (ladder)** – priedai nustatomi iš `volume_ladder` ir `triage_ladder` lentelių.
+
 Biudžeto planavimo įrankyje galima nurodyti minimalų gydytojų, slaugytojų ir padėjėjų skaičių. Šios reikšmės (`minDoctor`, `minNurse`, `minAssistant`) naudojamos optimizacijos metu, kad siūlomas personalo skaičius niekada nenukristų žemiau nustatytų ribų.
 
 ## Vykdymas vietoje

--- a/index.html
+++ b/index.html
@@ -213,6 +213,7 @@
               <!-- formerly id="kmax" -->
             </div>
           </div>
+          <div id="formulaInfo"></div>
           <div class="row-3">
             <div>
               <label for="minDoctor">Min. gydytojų skaičius</label>


### PR DESCRIPTION
## Summary
- add formula info placeholder in advanced options and render based on selected formula
- support legacy static table and dynamic ladder tables from config
- document legacy vs ladder difference in README

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c2cc216d2c83209a0fdad29973df69