### PR TITLE
Use fieldset for advanced options

### DIFF
--- a/budget.html
+++ b/budget.html
@@ -184,8 +184,8 @@
         </div>
 
         <div class="step" data-step="4">
-        <details id="advanced-section" class="section" open>
-          <summary>Išplėstinės parinktys</summary>
+        <fieldset id="advanced-section" class="section">
+          <legend>Išplėstinės parinktys</legend>
           <div class="row">
             <div>
               <label for="maxCoefficient">Maksimalus koeficientas</label>
@@ -206,7 +206,7 @@
               <input id="minAssistant" type="number" min="0" step="1" value="0" />
             </div>
           </div>
-        </details>
+        </fieldset>
         <div class="step-nav actions">
           <button type="button" class="back-step">Atgal</button>
         </div>

--- a/index.html
+++ b/index.html
@@ -197,8 +197,8 @@
         </div>
 
         <div class="step" data-step="4">
-        <details id="advanced-section" class="section" open>
-          <summary>Išplėstinės parinktys</summary>
+        <fieldset id="advanced-section" class="section">
+          <legend>Išplėstinės parinktys</legend>
           <div class="row">
             <div>
               <label for="formula">Skaičiavimo formulė</label>
@@ -228,7 +228,7 @@
               <input id="minAssistant" type="number" min="0" step="1" value="0" />
             </div>
           </div>
-        </details>
+        </fieldset>
 
         <div class="actions">
           <button class="primary" id="reset">Išvalyti</button>

--- a/styles.css
+++ b/styles.css
@@ -125,9 +125,6 @@
     .staff-group { margin-top: 12px; padding: 12px; border: 1px solid var(--border); border-radius: 12px; }
     .staff-group h3 { margin: 0 0 8px; font-size: var(--font-base); color: var(--accent-2); font-weight: 600; }
     legend { font-size: var(--font-base); font-weight: 600; color: var(--accent-2); padding: 0 6px; }
-    details { margin: 14px 0; padding: 12px; border: 1px solid var(--border); border-radius: 12px; }
-    summary { cursor: pointer; font-size: var(--font-base); font-weight: 600; color: var(--accent-2); padding: 0 6px; }
-    summary::-webkit-details-marker { display: none; }
     .zone-row { grid-template-columns: 1fr auto; gap: 8px; }
     .help { font-size: var(--font-xs); color: var(--muted); margin-top: 6px; }
     .switch { display: inline-flex; align-items: center; gap: 8px; user-select: none; cursor: pointer; font-size: var(--font-sm); color: var(--muted); }


### PR DESCRIPTION
## Summary
- replace collapsible advanced options with a regular fieldset
- remove unused `details`/`summary` CSS rules

## Testing
- `npm test`
- `npm run lint` *(fails: Parsing error: 'import' and 'export' may appear only with 'sourceType: module')*


------
https://chatgpt.com/codex/tasks/task_e_68c7fbfadbd88320a5b3ea9b4a4db2d0