### PR TITLE
feat: add minimal game module

### DIFF
--- a/game/README.md
+++ b/game/README.md
@@ -1,0 +1,16 @@
+# Mini žaidimo modulis
+
+Paprasta struktūra su būsenos mašina ir DOM atvaizdavimu.
+
+## Naudojimas
+
+1. Į HTML įtrauk `<script type="module" src="./game/main.js"></script>`.
+2. HTML turėk elementus: `#start`, `#submit`, `#answer`, `#result`.
+3. Atidarius puslapį gali pradėti žaidimą.
+
+## Smoke test
+
+- Atidaryk HTML naršyklėje.
+- Spausk **Start**.
+- Įvesk `42` ir spausk **Submit**.
+- Rezultatas turėtų rodyti `Taškai: 1`.

--- a/game/engine.js
+++ b/game/engine.js
@@ -1,0 +1,38 @@
+import { state } from './state.js';
+
+/**
+ * Paprasta būsenos mašina: init -> startRound -> submit -> showResult
+ */
+export class Engine {
+  constructor() {
+    this.current = 'init';
+  }
+
+  /** Inicializuoja žaidimą */
+  init(data = null) {
+    state.roundData = data;
+    state.score = 0;
+    this.current = 'init';
+  }
+
+  /** Pradeda raundą */
+  startRound(data) {
+    state.roundData = data;
+    this.current = 'startRound';
+  }
+
+  /** Pateikia atsakymą */
+  submit(answer) {
+    if (state.roundData && answer === state.roundData.correct) {
+      state.score += 1;
+    }
+    this.current = 'submit';
+  }
+
+  /** Parodo rezultatą ir išsaugo rekordus */
+  showResult() {
+    state.highScores.push(state.score);
+    this.current = 'showResult';
+    return state.score;
+  }
+}

--- a/game/main.js
+++ b/game/main.js
@@ -1,0 +1,24 @@
+import { Engine } from './engine.js';
+import { initView } from './view.js';
+import { state } from './state.js';
+
+const engine = new Engine();
+
+function startGame() {
+  engine.init();
+  initView({
+    onStart: () => engine.startRound({ correct: '42' }),
+    onSubmit: (answer) => {
+      engine.submit(answer);
+      engine.showResult();
+    },
+  });
+}
+
+// automatiškai inicijuoja žaidimą
+document.addEventListener('DOMContentLoaded', () => {
+  startGame();
+});
+
+// eksportuojama testams ar plėtimui
+export { startGame, state, engine };

--- a/game/state.js
+++ b/game/state.js
@@ -1,0 +1,5 @@
+export const state = {
+  roundData: null, // dabartinio raundo duomenys
+  score: 0, // surinkti taškai
+  highScores: [], // geriausi rezultatai
+};

--- a/game/view.js
+++ b/game/view.js
@@ -1,0 +1,28 @@
+import { state } from './state.js';
+
+/**
+ * Atvaizduoja būseną ir valdo įvykius
+ */
+export function initView({ onStart, onSubmit }) {
+  const startBtn = document.getElementById('start');
+  const submitBtn = document.getElementById('submit');
+  const answerInput = document.getElementById('answer');
+
+  startBtn?.addEventListener('click', () => {
+    onStart();
+    render();
+  });
+
+  submitBtn?.addEventListener('click', () => {
+    onSubmit(answerInput?.value || '');
+    render();
+  });
+}
+
+/** Atvaizduoja rezultatą ekrane */
+export function render() {
+  const result = document.getElementById('result');
+  if (result) {
+    result.textContent = `Taškai: ${state.score}`;
+  }
+}

--- a/tests/game-engine.test.js
+++ b/tests/game-engine.test.js
@@ -1,0 +1,21 @@
+import { Engine } from '../game/engine.js';
+import { state } from '../game/state.js';
+
+describe('Engine state machine', () => {
+  test('lifecycle', () => {
+    const engine = new Engine();
+    engine.init();
+    expect(engine.current).toBe('init');
+
+    engine.startRound({ correct: '42' });
+    expect(engine.current).toBe('startRound');
+
+    engine.submit('42');
+    expect(engine.current).toBe('submit');
+
+    const result = engine.showResult();
+    expect(engine.current).toBe('showResult');
+    expect(result).toBe(1);
+    expect(state.score).toBe(1);
+  });
+});


### PR DESCRIPTION
## Summary
- add basic state machine for rounds and scoring
- render and wire DOM events for start and submit buttons
- include simple test for engine lifecycle

## Testing
- `npm test`
- `npm run lint` *(fails: Parsing error: 'import' and 'export' may appear only with 'sourceType: module')*

------
https://chatgpt.com/codex/tasks/task_e_68c81d50c1508320bbab5c49cfe6da76