### PR TITLE
feat(game): add level configs and simulation

### DIFF
--- a/game/README.md
+++ b/game/README.md
@@ -1,16 +1,17 @@
 # Mini žaidimo modulis
 
-Paprasta struktūra su būsenos mašina ir DOM atvaizdavimu.
+Paprasta struktūra su būsenos mašina ir DOM atvaizdavimu. Lygiai apibrėžti `levels.js` faile.
 
 ## Naudojimas
 
 1. Į HTML įtrauk `<script type="module" src="./game/main.js"></script>`.
 2. HTML turėk elementus: `#start`, `#submit`, `#answer`, `#result`.
-3. Atidarius puslapį gali pradėti žaidimą.
+3. `onStart` kviečia `engine.startRound(0)` ir parenka pirmo lygio konfigūraciją.
 
 ## Smoke test
 
 - Atidaryk HTML naršyklėje.
 - Spausk **Start**.
-- Įvesk `42` ir spausk **Submit**.
+- Naršyklės konsolėje `game.state.roundData.correct` parodys teisingą atsakymą.
+- Įvesk šį skaičių ir spausk **Submit**.
 - Rezultatas turėtų rodyti `Taškai: 1`.

--- a/game/engine.js
+++ b/game/engine.js
@@ -1,4 +1,6 @@
 import { state } from './state.js';
+import { simulateEsiCounts } from '../simulation.js';
+import { levels } from './levels.js';
 
 /**
  * Paprasta būsenos mašina: init -> startRound -> submit -> showResult
@@ -15,9 +17,14 @@ export class Engine {
     this.current = 'init';
   }
 
-  /** Pradeda raundą */
-  startRound(data) {
-    state.roundData = data;
+  /**
+   * Pradeda raundą pagal lygį
+   * @param {number} level Indexas iš levels masyvo
+   */
+  startRound(level = 0) {
+    const config = levels[level] || levels[0];
+    const esi = simulateEsiCounts(config.kMax, config.capacity);
+    state.roundData = { config, esi, correct: String(esi.total) };
     this.current = 'startRound';
   }
 

--- a/game/levels.js
+++ b/game/levels.js
@@ -1,0 +1,7 @@
+export const levels = [
+  { capacity: 20, kMax: 10, timeLimit: 60 },
+  { capacity: 40, kMax: 20, timeLimit: 45 },
+  { capacity: 60, kMax: 30, timeLimit: 30 }
+];
+
+export default levels;

--- a/game/main.js
+++ b/game/main.js
@@ -3,11 +3,15 @@ import { initView } from './view.js';
 import { state } from './state.js';
 
 const engine = new Engine();
+// eksponuojama debug'ui konsolėje
+if (typeof window !== 'undefined') {
+  window.game = { state, engine };
+}
 
 function startGame() {
   engine.init();
   initView({
-    onStart: () => engine.startRound({ correct: '42' }),
+    onStart: () => engine.startRound(0),
     onSubmit: (answer) => {
       engine.submit(answer);
       engine.showResult();

--- a/tests/engine.test.js
+++ b/tests/engine.test.js
@@ -1,0 +1,22 @@
+import { Engine } from '../game/engine.js';
+import { state } from '../game/state.js';
+import { levels } from '../game/levels.js';
+import { simulateEsiCounts } from '../simulation.js';
+
+jest.mock('../simulation.js', () => ({
+  simulateEsiCounts: jest.fn(() => ({ total: 5, counts: [1,1,1,1,1] })),
+}));
+
+describe('engine.startRound', () => {
+  beforeEach(() => {
+    state.roundData = null;
+  });
+
+  test('pasirenka lygio konfigūraciją ir kviečia simulateEsiCounts', () => {
+    const engine = new Engine();
+    engine.startRound(1);
+    expect(simulateEsiCounts).toHaveBeenCalledWith(levels[1].kMax, levels[1].capacity);
+    expect(state.roundData.config).toEqual(levels[1]);
+    expect(state.roundData.esi.total).toBe(5);
+  });
+});

--- a/tests/game-engine.test.js
+++ b/tests/game-engine.test.js
@@ -7,10 +7,10 @@ describe('Engine state machine', () => {
     engine.init();
     expect(engine.current).toBe('init');
 
-    engine.startRound({ correct: '42' });
+    engine.startRound(0);
     expect(engine.current).toBe('startRound');
 
-    engine.submit('42');
+    engine.submit(state.roundData.correct);
     expect(engine.current).toBe('submit');
 
     const result = engine.showResult();


### PR DESCRIPTION
## Summary
- add `levels.js` with capacity, kMax and timeLimit
- wire `engine.startRound` to pick config and simulate ESI counts
- expose engine/state for debugging and document level usage
- add unit test for engine level selection

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c81fe2e8ec83209263ba89b1e8bd5a