### PR TITLE
feat(game): add high score tracking

### DIFF
--- a/game/README.md
+++ b/game/README.md
@@ -5,7 +5,7 @@ Paprasta struktūra su būsenos mašina ir DOM atvaizdavimu. Lygiai apibrėžti 
 ## Naudojimas
 
 1. Į HTML įtrauk `<script type="module" src="./game/main.js"></script>`.
-2. HTML turėk elementus: `#start`, `#submit`, `#answer`, `#result`.
+2. HTML turėk elementus: `#start`, `#submit`, `#answer`, `#result`, `#highscores` (ul ar ol).
 3. `onStart` kviečia `engine.startRound(0)` ir parenka pirmo lygio konfigūraciją.
 
 ## Smoke test
@@ -14,4 +14,5 @@ Paprasta struktūra su būsenos mašina ir DOM atvaizdavimu. Lygiai apibrėžti 
 - Spausk **Start**.
 - Naršyklės konsolėje `game.state.roundData.correct` parodys teisingą atsakymą.
 - Įvesk šį skaičių ir spausk **Submit**.
-- Rezultatas turėtų rodyti `Taškai: 1`.
+- Rezultatas turėtų rodyti surinktus taškus, pvz., `Taškai: 10` jei atsakyta greitai.
+- `#highscores` sąraše matysis geriausi rezultatai (top 5).

--- a/game/engine.js
+++ b/game/engine.js
@@ -14,6 +14,7 @@ export class Engine {
   init(data = null) {
     state.roundData = data;
     state.score = 0;
+    state.loadHighScores();
     this.current = 'init';
   }
 
@@ -25,20 +26,34 @@ export class Engine {
     const config = levels[level] || levels[0];
     const esi = simulateEsiCounts(config.kMax, config.capacity);
     state.roundData = { config, esi, correct: String(esi.total) };
+    state.startTime = Date.now();
     this.current = 'startRound';
+  }
+
+  /**
+   * Įvertina atsakymą ir grąžina taškus
+   * @param {string} answer Vartotojo atsakymas
+   * @param {number} timeMs Laikas ms nuo raundo pradžios
+   * @returns {number} gauti taškai
+   */
+  checkAnswer(answer, timeMs) {
+    if (!state.roundData || answer !== state.roundData.correct) return 0;
+    const seconds = Math.floor(timeMs / 1000);
+    return Math.max(1, 10 - seconds); // kuo greičiau, tuo daugiau taškų
   }
 
   /** Pateikia atsakymą */
   submit(answer) {
-    if (state.roundData && answer === state.roundData.correct) {
-      state.score += 1;
-    }
+    const timeMs = Date.now() - state.startTime;
+    const points = this.checkAnswer(answer, timeMs);
+    state.score += points;
     this.current = 'submit';
+    return points;
   }
 
   /** Parodo rezultatą ir išsaugo rekordus */
   showResult() {
-    state.highScores.push(state.score);
+    state.saveHighScore(state.score);
     this.current = 'showResult';
     return state.score;
   }

--- a/game/main.js
+++ b/game/main.js
@@ -1,5 +1,5 @@
 import { Engine } from './engine.js';
-import { initView } from './view.js';
+import { initView, render } from './view.js';
 import { state } from './state.js';
 
 const engine = new Engine();
@@ -17,6 +17,7 @@ function startGame() {
       engine.showResult();
     },
   });
+  render();
 }
 
 // automatiškai inicijuoja žaidimą

--- a/game/state.js
+++ b/game/state.js
@@ -1,5 +1,39 @@
+/** LocalStorage raktas geriausiems rezultatams */
+export const GAME_HIGHSCORES = 'GAME_HIGHSCORES';
+
 export const state = {
   roundData: null, // dabartinio raundo duomenys
   score: 0, // surinkti taškai
   highScores: [], // geriausi rezultatai
+  startTime: 0, // raundo pradžios laikas
+
+  /** Perskaito rekordus iš LocalStorage */
+  loadHighScores() {
+    if (typeof localStorage === 'undefined') {
+      this.highScores = [];
+      return;
+    }
+
+    try {
+      const saved = localStorage.getItem(GAME_HIGHSCORES);
+      this.highScores = saved ? JSON.parse(saved) : [];
+    } catch {
+      this.highScores = [];
+    }
+  },
+
+  /**
+   * Išsaugo rezultatą LocalStorage.
+   * @param {number} score Gauti taškai
+   */
+  saveHighScore(score) {
+    if (typeof localStorage === 'undefined') return;
+    const scores = [...this.highScores, score].sort((a, b) => b - a).slice(0, 5);
+    this.highScores = scores;
+    try {
+      localStorage.setItem(GAME_HIGHSCORES, JSON.stringify(scores));
+    } catch {
+      // saugojimo klaidos nutylimos
+    }
+  },
 };

--- a/game/view.js
+++ b/game/view.js
@@ -25,4 +25,17 @@ export function render() {
   if (result) {
     result.textContent = `Taškai: ${state.score}`;
   }
+  renderHighScores();
+}
+
+/** Rodo top 5 rezultatų sąrašą */
+export function renderHighScores() {
+  const list = document.getElementById('highscores');
+  if (!list) return;
+  list.innerHTML = '';
+  state.highScores.slice(0, 5).forEach((score, i) => {
+    const li = document.createElement('li');
+    li.textContent = `${i + 1}. ${score}`;
+    list.appendChild(li);
+  });
 }

--- a/tests/game-engine.test.js
+++ b/tests/game-engine.test.js
@@ -1,8 +1,12 @@
 import { Engine } from '../game/engine.js';
-import { state } from '../game/state.js';
+import { state, GAME_HIGHSCORES } from '../game/state.js';
 
 describe('Engine state machine', () => {
-  test('lifecycle', () => {
+  beforeEach(() => {
+    localStorage.clear();
+  });
+
+  test('lifecycle and scoring', () => {
     const engine = new Engine();
     engine.init();
     expect(engine.current).toBe('init');
@@ -10,12 +14,16 @@ describe('Engine state machine', () => {
     engine.startRound(0);
     expect(engine.current).toBe('startRound');
 
+    // fiksuojame 3 s vėlavimą
+    state.startTime = Date.now() - 3000;
     engine.submit(state.roundData.correct);
     expect(engine.current).toBe('submit');
 
     const result = engine.showResult();
     expect(engine.current).toBe('showResult');
-    expect(result).toBe(1);
-    expect(state.score).toBe(1);
+    expect(result).toBe(7);
+    expect(state.score).toBe(7);
+    const stored = JSON.parse(localStorage.getItem(GAME_HIGHSCORES));
+    expect(stored[0]).toBe(7);
   });
 });

--- a/tests/game-view.test.js
+++ b/tests/game-view.test.js
@@ -1,0 +1,12 @@
+import { renderHighScores } from '../game/view.js';
+import { state } from '../game/state.js';
+
+test('renderHighScores shows top 5 scores', () => {
+  document.body.innerHTML = '<ul id="highscores"></ul>';
+  state.highScores = [10, 8, 6, 4, 2, 1];
+  renderHighScores();
+  const items = document.querySelectorAll('#highscores li');
+  expect(items.length).toBe(5);
+  expect(items[0].textContent).toContain('10');
+  expect(items[4].textContent).toContain('2');
+});


### PR DESCRIPTION
## Summary
- score answer speed via `Engine.checkAnswer`
- persist top scores in `state.saveHighScore`
- render top 5 in `view.renderHighScores`

## Testing
- `npm test`
- `npm run lint` *(fails: expect/describe not defined, parsing errors)*

------
https://chatgpt.com/codex/tasks/task_e_68c821765ca48320a4e79fcd84e70888