### PR TITLE
Add navigation link to mini game

### DIFF
--- a/index.html
+++ b/index.html
@@ -39,6 +39,7 @@
       <div class="card">
         <h2>Įvestis</h2>
         <nav class="nav-sections">
+          <a href="game.html">Mini žaidimas</a>
           <a href="#shift-section">Pamainos parametrai</a>
           <a href="#patients-section">Pacientų pasiskirstymas</a>
           <a href="#staff-section">Darbuotojai</a>


### PR DESCRIPTION
## Summary
- add a navigation link in the calculator page to open the mini game demo

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68c842f6e00c832094c1263a9da24636