### PR TITLE
Remove mini-game button and rely on keyboard shortcut

### DIFF
--- a/app.js
+++ b/app.js
@@ -279,7 +279,10 @@ function handleMiniGameKeydown(event) {
 
 document.addEventListener('keydown', handleMiniGameKeydown, { passive: false });
 
-// Reikalaujamas įvykio registravimas (scenarijus įkeliamas su defer, todėl DOM jau paruoštas).
-document.getElementById('miniGameBtn').addEventListener('click', startMiniGame);
+// Jei ateityje bus pridėtas fizinis mygtukas – paliekame suderinamumą.
+const miniGameButton = document.getElementById('miniGameBtn');
+if (miniGameButton) {
+  miniGameButton.addEventListener('click', startMiniGame);
+}
 
 console.info('[MiniGame] Paruošta. ' + MINI_GAME_TEXT.shortcutHint);

--- a/index.html
+++ b/index.html
@@ -33,7 +33,6 @@
         <span>Šviesi tema</span>
       </label>
       <button id="budgetPlanner" type="button">Biudžeto planavimas</button>
-      <button id="miniGameBtn" type="button">Mini žaidimas</button>
     </div>
 
     <div class="grid grid-2 calc-grid">


### PR DESCRIPTION
## Summary
- remove the mini game trigger button from the main dashboard header
- guard the mini game script so it only binds the click handler when a trigger exists, relying on Ctrl/Cmd+M as the entry point

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68c91fe8d7f8832088b3749323dc11e2