### PR TITLE
Pašalintas mini žaidimo mygtukas iš pagrindinio puslapio

### DIFF
--- a/index.html
+++ b/index.html
@@ -39,7 +39,6 @@
       <div class="card">
         <h2>Įvestis</h2>
         <nav class="nav-sections">
-          <a href="game.html">Mini žaidimas</a>
           <a href="#shift-section">Pamainos parametrai</a>
           <a href="#patients-section">Pacientų pasiskirstymas</a>
           <a href="#staff-section">Darbuotojai</a>


### PR DESCRIPTION
## Summary
- remove the mini game navigation link from the main calculator page so the button no longer appears

## Testing
- not run (HTML-only change)


------
https://chatgpt.com/codex/tasks/task_e_68c94b6d47688320bb2ab2a528bcf917