### PR TITLE
Add danger pulse animation to suspicion bar

### DIFF
--- a/game/main.js
+++ b/game/main.js
@@ -158,6 +158,19 @@ const STYLE_CONTENT = `
   background: linear-gradient(90deg, rgba(248, 113, 113, 0.85), rgba(239, 68, 68, 1));
 }
 
+#suspicion-bar.danger {
+  animation: pulse 0.8s infinite alternate;
+}
+
+@keyframes pulse {
+  from {
+    filter: brightness(1);
+  }
+  to {
+    filter: brightness(1.6);
+  }
+}
+
 #suspicion-bar[data-mode='distracted'] {
   background: linear-gradient(90deg, rgba(251, 191, 36, 0.85), rgba(34, 197, 94, 0.95));
 }

--- a/game/view.js
+++ b/game/view.js
@@ -98,6 +98,11 @@ export function initView({
     fundsEl.textContent = formatCurrency(score);
     timerEl.textContent = formatTime(timeLeft);
     const percent = suspicionMax > 0 ? Math.round((suspicion / suspicionMax) * 100) : 0;
+    if (percent >= 85) {
+      suspicionBar.classList.add('danger');
+    } else {
+      suspicionBar.classList.remove('danger');
+    }
     suspicionBar.style.width = `${clamp(percent, 0, 100)}%`;
     suspicionBar.setAttribute('aria-valuenow', String(percent));
     suspicionBar.setAttribute('aria-valuemax', String(100));


### PR DESCRIPTION
## Summary
- add automatic `danger` class toggling when suspicion reaches 85%
- animate the suspicion bar with a pulse effect while in the danger state to emphasize urgency

## Testing
- npm test -- game-view.test.js

------
https://chatgpt.com/codex/tasks/task_e_68c96f6172b88320b1a0c78f9675c2a5