### PR TITLE
Expand game layout to use full window

### DIFF
--- a/game.html
+++ b/game.html
@@ -9,24 +9,41 @@
       color-scheme: dark;
     }
 
+    html,
+    body {
+      height: 100%;
+    }
+
     body {
       margin: 0;
       min-height: 100vh;
       background: radial-gradient(circle at top, #1e293b, #0f172a 60%);
       color: #f8fafc;
       display: flex;
-      align-items: flex-start;
-      justify-content: center;
-      padding: 2rem 1rem 3rem;
+      align-items: stretch;
+      justify-content: stretch;
       font-family: 'Segoe UI', system-ui, -apple-system, BlinkMacSystemFont, sans-serif;
     }
 
     #mini-game.dg-embed {
-      width: min(960px, 100%);
+      flex: 1;
+      display: flex;
+      align-items: stretch;
+      justify-content: center;
+      padding: clamp(1.5rem, 4vw, 3.5rem);
+      width: 100%;
+      min-height: 100vh;
+      box-sizing: border-box;
     }
 
     #mini-game.dg-embed > #game-root {
+      flex: 1;
+      display: flex;
+      align-items: center;
+      justify-content: center;
       width: 100%;
+      min-height: 100%;
+      box-sizing: border-box;
     }
   </style>
 </head>

--- a/game/main.js
+++ b/game/main.js
@@ -10,9 +10,14 @@ const STYLE_CONTENT = `
   font-family: 'Segoe UI', system-ui, -apple-system, BlinkMacSystemFont, sans-serif;
   color-scheme: dark;
   color: #f8fafc;
-  display: block;
-  padding: 1.5rem 0;
+  width: 100%;
+  min-height: 100%;
+  display: flex;
+  justify-content: center;
+  align-items: stretch;
+  padding: clamp(1.5rem, 4vw, 3.5rem);
   box-sizing: border-box;
+  flex: 1;
 }
 
 .dg-root * {
@@ -21,25 +26,33 @@ const STYLE_CONTENT = `
 
 .dg-embed {
   background: radial-gradient(circle at top, #1e293b, #0f172a 60%);
-  padding: 2rem 1rem 3rem;
+  min-height: 100vh;
+  width: 100%;
   display: flex;
+  align-items: stretch;
   justify-content: center;
-  align-items: flex-start;
+  padding: clamp(1.5rem, 4vw, 3.5rem);
+  box-sizing: border-box;
 }
 
 .dg-embed .dg-root {
-  width: min(960px, 100%);
+  padding: 0;
+  min-height: 100%;
+  width: 100%;
 }
 
 .dg-app {
-  width: min(960px, 100%);
+  width: 100%;
   background: rgba(15, 23, 42, 0.92);
-  border-radius: 18px;
-  padding: 2rem;
+  border-radius: 24px;
+  padding: clamp(1.75rem, 3.5vw, 3rem);
   box-shadow: 0 25px 60px rgba(15, 23, 42, 0.55);
   border: 1px solid rgba(148, 163, 184, 0.35);
   position: relative;
-  margin: 0 auto;
+  margin: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 0;
 }
 
 .dg-app h1 {
@@ -59,6 +72,8 @@ const STYLE_CONTENT = `
   gap: 1rem;
   margin: 1.8rem 0 1.2rem;
   align-items: flex-end;
+  width: 100%;
+  justify-content: space-between;
 }
 
 .dg-field {
@@ -117,9 +132,9 @@ const STYLE_CONTENT = `
 
 .dg-hud {
   display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
-  gap: 1rem;
-  margin-bottom: 1rem;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+  gap: 1.25rem;
+  margin-bottom: 1.5rem;
 }
 
 .dg-card {
@@ -183,18 +198,74 @@ const STYLE_CONTENT = `
 
 .dg-app canvas {
   width: 100%;
-  max-width: 720px;
+  height: auto;
   background: rgba(15, 23, 42, 0.8);
   border-radius: 16px;
   border: 1px solid rgba(148, 163, 184, 0.25);
   margin: 0 auto 2rem;
   display: block;
+  box-shadow: 0 20px 40px rgba(15, 23, 42, 0.4);
 }
 
 .dg-info-grid {
   display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
+  grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
   gap: 1.5rem;
+  width: 100%;
+}
+
+@media (min-width: 1200px) {
+  .dg-app {
+    display: grid;
+    grid-template-columns: minmax(0, 3fr) minmax(0, 2fr);
+    grid-template-areas:
+      'header sidebar'
+      'controls sidebar'
+      'level sidebar'
+      'hud sidebar'
+      'status sidebar'
+      'canvas sidebar';
+    column-gap: 2.5rem;
+    row-gap: 1.75rem;
+    align-items: start;
+  }
+
+  .dg-app header {
+    grid-area: header;
+  }
+
+  .dg-controls {
+    grid-area: controls;
+  }
+
+  .dg-level {
+    grid-area: level;
+  }
+
+  .dg-hud {
+    grid-area: hud;
+  }
+
+  .dg-status {
+    grid-area: status;
+  }
+
+  .dg-app canvas {
+    grid-area: canvas;
+    justify-self: stretch;
+    align-self: start;
+  }
+
+  .dg-info-grid {
+    grid-area: sidebar;
+    grid-template-columns: 1fr;
+    align-self: stretch;
+    align-content: start;
+  }
+
+  .dg-info-grid .dg-panel {
+    height: 100%;
+  }
 }
 
 .dg-panel {
@@ -262,13 +333,22 @@ const STYLE_CONTENT = `
 }
 
 @media (max-width: 720px) {
+  .dg-root {
+    padding: 1rem;
+  }
+
+  .dg-embed {
+    padding: 1rem;
+  }
+
   .dg-app {
-    padding: 1.5rem;
+    padding: 1.25rem;
   }
 
   .dg-controls {
     flex-direction: column;
     align-items: stretch;
+    justify-content: flex-start;
   }
 
   .dg-app button,
@@ -277,7 +357,7 @@ const STYLE_CONTENT = `
   }
 
   .dg-app canvas {
-    max-width: 100%;
+    margin: 0 0 1.5rem;
   }
 }
 `;
@@ -327,8 +407,8 @@ const GAME_TEMPLATE = `
 
   <canvas
     id="game-canvas"
-    width="720"
-    height="420"
+    width="1280"
+    height="720"
     role="img"
     aria-label="Žaidimo laukas: direktoriumi prižiūrima salė"
   >


### PR DESCRIPTION
## Summary
- stretch the standalone game embed to occupy the entire viewport space
- refresh in-game styles with responsive layout rules and a larger canvas for better use of wide screens

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68c9707a9f7083208e8f87d907cbcec3