### PR TITLE
Improve director and player shapes in game

### DIFF
--- a/game/engine.js
+++ b/game/engine.js
@@ -11,6 +11,25 @@ function randomRange([min, max]) {
   return min + Math.random() * (max - min);
 }
 
+/**
+ * Sukuria glotniai užapvalinto stačiakampio kontūrą.
+ * Keičiant spindulį galima greitai koreguoti personažų kūnų formą.
+ */
+function roundedRectPath(ctx, x, y, width, height, radius) {
+  const r = Math.min(radius, width / 2, height / 2);
+  ctx.beginPath();
+  ctx.moveTo(x + r, y);
+  ctx.lineTo(x + width - r, y);
+  ctx.quadraticCurveTo(x + width, y, x + width, y + r);
+  ctx.lineTo(x + width, y + height - r);
+  ctx.quadraticCurveTo(x + width, y + height, x + width - r, y + height);
+  ctx.lineTo(x + r, y + height);
+  ctx.quadraticCurveTo(x, y + height, x, y + height - r);
+  ctx.lineTo(x, y + r);
+  ctx.quadraticCurveTo(x, y, x + r, y);
+  ctx.closePath();
+}
+
 export class DirectorGameEngine {
   constructor(canvas, { onUpdate, onEnd } = {}) {
     this.canvas = canvas;
@@ -334,36 +353,227 @@ export class DirectorGameEngine {
 
   drawDirector(ctx) {
     const d = this.director;
-    const modeColor = d.mode === 'looking' ? '#f87171' : '#fb923c';
+    const isLooking = d.mode === 'looking';
+    const beamLength = isLooking ? 200 : 160;
 
     ctx.save();
     ctx.translate(d.x, d.y);
 
-    ctx.fillStyle = '#1e293b';
-    ctx.fillRect(0, 0, d.width, d.height);
+    const bodyWidth = d.width;
+    const bodyHeight = d.height;
+    const headRadius = bodyWidth * 0.28;
+    const headCenterX = bodyWidth / 2;
+    const headCenterY = headRadius + 6;
 
-    ctx.fillStyle = modeColor;
-    ctx.fillRect(d.width * 0.2, -18, d.width * 0.6, 18);
-
+    // Žvilgsnio kūgis – kuo žvilgsnis budresnis, tuo siauresnis ir raudonesnis spindulys.
     ctx.beginPath();
-    ctx.moveTo(d.width, d.height * 0.2);
-    ctx.lineTo(d.width + 140, d.height * 0.5);
-    ctx.lineTo(d.width, d.height * 0.8);
+    ctx.moveTo(bodyWidth * 0.92, headCenterY - headRadius * 0.75);
+    ctx.lineTo(bodyWidth * 0.92 + beamLength, headCenterY - headRadius * 0.25);
+    ctx.lineTo(bodyWidth * 0.92 + beamLength, headCenterY + headRadius * 0.25);
+    ctx.lineTo(bodyWidth * 0.92, headCenterY + headRadius * 0.75);
     ctx.closePath();
-    ctx.fillStyle = d.mode === 'looking' ? 'rgba(248, 113, 113, 0.25)' : 'rgba(253, 186, 116, 0.2)';
+    ctx.fillStyle = isLooking
+      ? 'rgba(248, 113, 113, 0.35)'
+      : 'rgba(253, 186, 116, 0.25)';
     ctx.fill();
 
+    // Šešėlis po direktoriaus kėde.
+    ctx.fillStyle = 'rgba(15, 23, 42, 0.35)';
+    roundedRectPath(ctx, bodyWidth * 0.05, bodyHeight - 10, bodyWidth * 0.9, 12, 6);
+    ctx.fill();
+
+    // Kėdės atlošas.
+    const chairGradient = ctx.createLinearGradient(0, bodyHeight * 0.18, 0, bodyHeight);
+    chairGradient.addColorStop(0, '#1f2937');
+    chairGradient.addColorStop(1, '#0f172a');
+    ctx.fillStyle = chairGradient;
+    roundedRectPath(ctx, -bodyWidth * 0.08, bodyHeight * 0.18, bodyWidth * 1.16, bodyHeight * 0.82, 18);
+    ctx.fill();
+
+    // Rankos ir kostiumo rankovės.
+    ctx.fillStyle = '#0f172a';
+    roundedRectPath(ctx, -bodyWidth * 0.18, bodyHeight * 0.38, bodyWidth * 0.38, bodyHeight * 0.42, 14);
+    ctx.fill();
+    roundedRectPath(ctx, bodyWidth * 0.8, bodyHeight * 0.38, bodyWidth * 0.38, bodyHeight * 0.42, 14);
+    ctx.fill();
+
+    // Kostiumo liemuo.
+    const suitGradient = ctx.createLinearGradient(0, bodyHeight * 0.25, 0, bodyHeight);
+    suitGradient.addColorStop(0, '#1e293b');
+    suitGradient.addColorStop(1, '#0b1220');
+    ctx.fillStyle = suitGradient;
+    roundedRectPath(ctx, 0, bodyHeight * 0.28, bodyWidth, bodyHeight * 0.7, 16);
+    ctx.fill();
+
+    // Marškinių apykaklė.
+    ctx.beginPath();
+    ctx.moveTo(bodyWidth * 0.1, bodyHeight * 0.32);
+    ctx.lineTo(bodyWidth * 0.5, bodyHeight * 0.44);
+    ctx.lineTo(bodyWidth * 0.9, bodyHeight * 0.32);
+    ctx.closePath();
+    ctx.fillStyle = '#e2e8f0';
+    ctx.fill();
+
+    // Kaklaraištis – keisk spalvą, jei reikia žaidime išskirti kitą direktorių.
+    ctx.beginPath();
+    ctx.moveTo(bodyWidth * 0.5, bodyHeight * 0.38);
+    ctx.lineTo(bodyWidth * 0.58, bodyHeight * 0.72);
+    ctx.lineTo(bodyWidth * 0.42, bodyHeight * 0.72);
+    ctx.closePath();
+    ctx.fillStyle = '#b91c1c';
+    ctx.fill();
+
+    // Kišenė su raudonu įspėjimo dokumentu.
+    ctx.fillStyle = '#1f2937';
+    roundedRectPath(ctx, bodyWidth * 0.64, bodyHeight * 0.5, bodyWidth * 0.22, bodyHeight * 0.18, 6);
+    ctx.fill();
+    ctx.fillStyle = isLooking ? '#f87171' : '#fb923c';
+    roundedRectPath(ctx, bodyWidth * 0.68, bodyHeight * 0.52, bodyWidth * 0.14, bodyHeight * 0.12, 4);
+    ctx.fill();
+
+    // Galva su akimis ir antakiais.
+    ctx.beginPath();
+    ctx.fillStyle = '#fcd5b5';
+    ctx.arc(headCenterX, headCenterY, headRadius, 0, TAU);
+    ctx.fill();
+
+    // Plaukai.
+    ctx.beginPath();
+    ctx.fillStyle = '#0f172a';
+    ctx.arc(headCenterX, headCenterY - headRadius * 0.15, headRadius * 1.05, Math.PI, 0, false);
+    ctx.closePath();
+    ctx.fill();
+
+    // Akys – kai žiūri, vyzdžiai susiaurėja.
+    const eyeOffsetX = headRadius * 0.38;
+    const eyeRadius = isLooking ? headRadius * 0.12 : headRadius * 0.16;
+    ctx.fillStyle = '#0f172a';
+    ctx.beginPath();
+    ctx.arc(headCenterX - eyeOffsetX, headCenterY, eyeRadius, 0, TAU);
+    ctx.arc(headCenterX + eyeOffsetX, headCenterY, eyeRadius, 0, TAU);
+    ctx.fill();
+
+    // Antakiai parodo režimą.
+    ctx.strokeStyle = isLooking ? '#b91c1c' : '#fb923c';
+    ctx.lineWidth = 3;
+    ctx.lineCap = 'round';
+    ctx.beginPath();
+    ctx.moveTo(headCenterX - eyeOffsetX - 6, headCenterY - headRadius * 0.4);
+    ctx.lineTo(headCenterX - eyeOffsetX + 6, headCenterY - headRadius * 0.45);
+    ctx.moveTo(headCenterX + eyeOffsetX - 6, headCenterY - headRadius * 0.45);
+    ctx.lineTo(headCenterX + eyeOffsetX + 6, headCenterY - headRadius * 0.4);
+    ctx.stroke();
+
+    // Grąžiname pradinę būseną.
     ctx.restore();
   }
 
   drawPlayer(ctx) {
     const p = this.player;
     const flash = this.scoreFlash > 0 ? 0.35 : 0;
-    ctx.fillStyle = `rgba(56, 189, 248, ${0.75 + flash})`;
-    ctx.fillRect(p.x, p.y, p.width, p.height);
 
-    ctx.fillStyle = '#0ea5e9';
-    ctx.fillRect(p.x + p.width * 0.25, p.y - 12, p.width * 0.5, 12);
+    ctx.save();
+    ctx.translate(p.x, p.y);
+
+    const width = p.width;
+    const height = p.height;
+    const torsoHeight = height * 0.62;
+    const torsoWidth = width * 0.72;
+    const torsoX = (width - torsoWidth) / 2;
+    const torsoY = height - torsoHeight;
+
+    // Kuprinė – indikacija, kad personažas renka aplankus.
+    ctx.fillStyle = `rgba(12, 74, 110, ${0.45 + flash / 2})`;
+    roundedRectPath(ctx, torsoX - 12, torsoY + 4, torsoWidth + 24, torsoHeight * 0.9, 16);
+    ctx.fill();
+
+    // Torso gradientas.
+    const torsoGradient = ctx.createLinearGradient(0, torsoY, 0, torsoY + torsoHeight);
+    torsoGradient.addColorStop(0, `rgba(56, 189, 248, ${0.9 + flash})`);
+    torsoGradient.addColorStop(1, `rgba(14, 165, 233, ${0.85 + flash})`);
+    ctx.fillStyle = torsoGradient;
+    roundedRectPath(ctx, torsoX, torsoY, torsoWidth, torsoHeight, 14);
+    ctx.fill();
+
+    // Diržas.
+    ctx.fillStyle = '#0284c7';
+    roundedRectPath(ctx, torsoX + 4, torsoY + torsoHeight * 0.55, torsoWidth - 8, 6, 3);
+    ctx.fill();
+
+    // Rankos.
+    ctx.fillStyle = `rgba(59, 130, 246, ${0.9 + flash / 2})`;
+    roundedRectPath(ctx, torsoX - 14, torsoY + 10, 14, torsoHeight * 0.55, 8);
+    ctx.fill();
+    roundedRectPath(ctx, torsoX + torsoWidth, torsoY + 10, 14, torsoHeight * 0.55, 8);
+    ctx.fill();
+
+    // Rankų delnai.
+    ctx.fillStyle = '#fde68a';
+    ctx.beginPath();
+    ctx.arc(torsoX - 7, torsoY + torsoHeight * 0.58, 6, 0, TAU);
+    ctx.arc(torsoX + torsoWidth + 7, torsoY + torsoHeight * 0.58, 6, 0, TAU);
+    ctx.fill();
+
+    // Kojos.
+    const legHeight = height - (torsoY + torsoHeight) + 6;
+    const legWidth = torsoWidth * 0.36;
+    ctx.fillStyle = '#0f172a';
+    roundedRectPath(ctx, torsoX + 6, height - legHeight, legWidth, legHeight, 6);
+    ctx.fill();
+    roundedRectPath(ctx, torsoX + torsoWidth - legWidth - 6, height - legHeight, legWidth, legHeight, 6);
+    ctx.fill();
+
+    // Batai.
+    ctx.fillStyle = '#082f49';
+    roundedRectPath(ctx, torsoX + 2, height - 8, legWidth + 10, 8, 4);
+    ctx.fill();
+    roundedRectPath(ctx, torsoX + torsoWidth - legWidth - 12, height - 8, legWidth + 10, 8, 4);
+    ctx.fill();
+
+    // Galva ir šalmas.
+    const headRadius = width * 0.26;
+    const headCenterX = width / 2;
+    const headCenterY = headRadius;
+    ctx.beginPath();
+    ctx.fillStyle = '#fde68a';
+    ctx.arc(headCenterX, headCenterY, headRadius, 0, TAU);
+    ctx.fill();
+
+    // Apsauginis skydelis – parodo atsargų darbą.
+    ctx.fillStyle = `rgba(191, 219, 254, ${0.7 + flash / 3})`;
+    roundedRectPath(ctx, headCenterX - headRadius * 0.8, headCenterY - headRadius * 0.6, headRadius * 1.6, headRadius * 0.9, 12);
+    ctx.fill();
+
+    // Akys.
+    ctx.fillStyle = '#0f172a';
+    ctx.beginPath();
+    ctx.arc(headCenterX - headRadius * 0.35, headCenterY, headRadius * 0.14, 0, TAU);
+    ctx.arc(headCenterX + headRadius * 0.35, headCenterY, headRadius * 0.14, 0, TAU);
+    ctx.fill();
+
+    // Antakiai ir šypsena suteikia gyvybingumo.
+    ctx.strokeStyle = '#1e293b';
+    ctx.lineWidth = 2;
+    ctx.lineCap = 'round';
+    ctx.beginPath();
+    ctx.moveTo(headCenterX - headRadius * 0.5, headCenterY - headRadius * 0.45);
+    ctx.lineTo(headCenterX - headRadius * 0.2, headCenterY - headRadius * 0.35);
+    ctx.moveTo(headCenterX + headRadius * 0.2, headCenterY - headRadius * 0.35);
+    ctx.lineTo(headCenterX + headRadius * 0.5, headCenterY - headRadius * 0.45);
+    ctx.stroke();
+    ctx.beginPath();
+    ctx.arc(headCenterX, headCenterY + headRadius * 0.25, headRadius * 0.35, 0, Math.PI);
+    ctx.stroke();
+
+    // Švytėjimo kontūras, kai surenkami pinigai.
+    if (flash > 0) {
+      ctx.strokeStyle = `rgba(255, 255, 255, ${flash})`;
+      ctx.lineWidth = 3;
+      roundedRectPath(ctx, torsoX - 16, torsoY - 12, torsoWidth + 32, torsoHeight + 24, 20);
+      ctx.stroke();
+    }
+
+    ctx.restore();
   }
 
   finish(reason) {


### PR DESCRIPTION
## Summary
- add a reusable rounded rectangle path helper for drawing smoother silhouettes
- redesign the director with a chair, outfit details, and a dynamic gaze cone tied to alert state
- redraw the player with layered torso, backpack, and energy outline that reacts to score pickups

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68c988d64c7083208d26b64bfefe483d