### PR TITLE
Add touch joystick controls for game

### DIFF
--- a/game/README.md
+++ b/game/README.md
@@ -24,7 +24,7 @@ game/strings.js     – visos LT tekstinės eilutės
    - **Netikėtas auditas** – įtarimas kyla žaibiškai, reikia daugiau manevrų.
    - **Ministerijos inspektorius** – galutinis iššūkis su aukščiausiais įkainiais.
 3. Spausk **„Pradėti misiją“**. Direktorius pradeda žiūrėti/nusisukti.
-4. Naudok **rodyklių arba WASD klavišus** judėti, kai direktorius išsiblaškęs. Kai žiūri – sustok.
+4. Naudok **rodyklių arba WASD klavišus** judėti, kai direktorius išsiblaškęs. Kai žiūri – sustok. Lietimui po drobe automatiškai pasirodo virtualios rodyklės – paspausk ir laikyk kryptį.
 5. Rink žalius grantų aplankus. Laikmatis parodo, kiek dar turi laiko.
 6. Kai laikas baigsis arba direktorius pagaus – gausi rezultatą, o sumos įrašomos į vietinius rekordus.
 
@@ -32,9 +32,16 @@ game/strings.js     – visos LT tekstinės eilutės
 
 - [ ] Atidaryta `game.html`, matomas Canvas, HUD ir valdikliai.
 - [ ] Pasirinktas lygis, paspausta „Pradėti misiją“ – drobėje juda personažas, atsiranda žali aplankai.
+- [ ] Naršyklėje įjungtas „Device Toolbar“ (ar realiame planšetės/telefono įrenginyje) – po drobe pasirodo lietimo valdiklių kryžiukas, laikant kryptį personažas juda be klaviatūros.
 - [ ] Įtarimo juosta kinta priklausomai nuo judėjimo, laikmatis skaičiuoja žemyn.
 - [ ] Pasiekus 0 s rodomas rezultatų perdangos langas ir įrašomas rekordas.
 - [ ] Mygtukas „Išvalyti rekordus“ ištrina vietinius rezultatus.
+
+## Mobilus naudojimas
+
+- Virtualios rodyklės aktyvuojamos tik kai įrenginys praneša apie `pointer: coarse` (telefonai/planšetės). Staliniams kompiuteriams jos nerodomos.
+- Geriausia testuoti įjungus „Device Toolbar“ (Chrome DevTools → Toggle device toolbar) arba realiame įrenginyje – drobė lieka laisva, valdikliai atsiranda apačioje.
+- Jei rodyklės užstringa (nutrūkęs „pointerup“ įvykis), užtenka trumpai paliesti drobę arba paspausti „Restart“ – kryptys automatiškai išvalomos.
 
 ## Dažniausios problemos
 

--- a/game/main.js
+++ b/game/main.js
@@ -261,6 +261,62 @@ const STYLE_CONTENT = `
   color: rgba(148, 163, 184, 0.85);
 }
 
+.dg-touch-controls {
+  display: flex;
+  justify-content: center;
+  margin: 0 auto 1.5rem;
+  max-width: min(320px, 100%);
+  pointer-events: none;
+}
+
+.dg-touch-controls__pad {
+  width: 100%;
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  grid-template-rows: repeat(3, minmax(0, 1fr));
+  gap: 0.75rem;
+  pointer-events: auto;
+}
+
+.dg-touch-controls__spacer {
+  display: block;
+}
+
+.dg-touch-button {
+  border: none;
+  border-radius: 16px;
+  background: linear-gradient(135deg, rgba(59, 130, 246, 0.9), rgba(14, 165, 233, 0.9));
+  color: #082f49;
+  font-weight: 700;
+  font-size: 1.35rem;
+  box-shadow: 0 16px 26px rgba(14, 165, 233, 0.32);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  aspect-ratio: 1 / 1;
+  min-height: 64px;
+  touch-action: none;
+  user-select: none;
+  transition: transform 120ms ease, box-shadow 150ms ease;
+}
+
+.dg-touch-button:active {
+  transform: scale(0.96);
+  box-shadow: 0 10px 20px rgba(14, 165, 233, 0.28);
+}
+
+.dg-touch-button:focus-visible {
+  outline: 3px solid rgba(56, 189, 248, 0.85);
+  outline-offset: 3px;
+}
+
+@media (max-width: 540px) {
+  .dg-touch-button {
+    min-height: 56px;
+    font-size: 1.1rem;
+  }
+}
+
 @media (max-width: 720px) {
   .dg-app {
     padding: 1.5rem;
@@ -432,6 +488,12 @@ function boot() {
     },
     onClearScores: () => {
       state.clearHighScores();
+    },
+    onDirectionalInput: (direction, isActive) => {
+      engine?.setDirectionalInput?.(direction, isActive);
+    },
+    onDirectionalClear: () => {
+      engine?.clearDirectionalInput?.();
     },
   });
 

--- a/game/strings.js
+++ b/game/strings.js
@@ -15,6 +15,7 @@ export const STRINGS = {
     'Kai direktorius žiūri (raudonas žvilgsnis) – lik vietoje, kitaip įtarimas auga.',
     'Surink grantų aplankus (žalsvi) ir laimėk kuo daugiau eurų.',
     'Laikas ribotas – kai baigsis, gausi tiek lėšų, kiek sukaupei.',
+    'Telefonuose ir planšetėse po drobe rodoma virtuali valdymo kryžmė.',
   ],
   lookingWarning: 'Direktorius stebi – stovėk ramiai!',
   distractedInfo: 'Direktorius išsiblaškęs, judėk!',
@@ -28,6 +29,7 @@ export const STRINGS = {
   localOnly: 'Rezultatai saugomi tik šioje naršyklėje.',
   overlayButton: 'Dar kartą!',
   shortcuts: 'Klaviatūra: rodyklės / WASD judėjimui, tarpas – trumpam sustoti.',
+  touchHint: 'Lietimas: naudok ekranines rodykles apačioje.',
 };
 
 export function formatTime(totalSeconds) {


### PR DESCRIPTION
## Summary
- add coarse pointer touch controls beneath the game canvas and style them to stay out of the way
- extend the engine input layer with directional setters used by the virtual joystick while keeping keyboard support intact
- update strings and documentation with mobile usage guidance and smoke testing steps

## Testing
- npm test -- tests/game-view.test.js

------
https://chatgpt.com/codex/tasks/task_e_68c9b0d97f448320812b484e3a9b9185